### PR TITLE
Popover improvements

### DIFF
--- a/demo/DemoPopoverSection.jsx
+++ b/demo/DemoPopoverSection.jsx
@@ -29,6 +29,10 @@ var DemoPopoverSection = React.createClass({
     this.setState({bottomRightPopoverOpen: false});
   },
 
+  _getBottomLeftButton: function () {
+    return React.findDOMNode(this.refs.bottomLeftButton);
+  },
+
   render: function () {
     return (
       <div className='rs-detail-section'>
@@ -54,8 +58,8 @@ var DemoPopoverSection = React.createClass({
                   <DemoPopover placement='bottom-right' target='bottom-right-button-id' isOpen={this.state.bottomRightPopoverOpen} onRequestClose={this._shouldCloseBottomRightPopover}/>
                 </td>
                 <td>
-                  <Button id='bottom-left-button-id' onClick={function () {this.setState({bottomLeftPopoverOpen: true});}.bind(this)}>Bottom Left</Button>
-                  <DemoPopover placement='bottom-left' target='bottom-left-button-id' isOpen={this.state.bottomLeftPopoverOpen} onRequestClose={this._shouldCloseBottomLeftPopover}/>
+                  <Button id='bottom-left-button-id' ref='bottomLeftButton' onClick={function () {this.setState({bottomLeftPopoverOpen: true});}.bind(this)}>Bottom Left</Button>
+                  <DemoPopover placement='bottom-left' target={this._getBottomLeftButton} isOpen={this.state.bottomLeftPopoverOpen} onRequestClose={this._shouldCloseBottomLeftPopover}/>
                 </td>
               </tr>
             </tbody>

--- a/demo/DemoPopoverSection.jsx
+++ b/demo/DemoPopoverSection.jsx
@@ -9,7 +9,9 @@ var DemoPopoverSection = React.createClass({
       rightPopoverOpen: false,
       leftPopoverOpen: false,
       bottomRightPopoverOpen: false,
-      bottomLeftPopoverOpen: false
+      bottomLeftPopoverOpen: false,
+      bottomRightFunctionPopoverOpen: false,
+      bottomLeftModalPopoverOpen: false
     };
   },
 
@@ -27,6 +29,14 @@ var DemoPopoverSection = React.createClass({
 
   _shouldCloseBottomRightPopover: function () {
     this.setState({bottomRightPopoverOpen: false});
+  },
+
+  _shouldCloseBottomRightFunctionPopover: function () {
+    this.setState({bottomRightFunctionPopoverOpen: false});
+  },
+
+  _shouldCloseBottomLeftModalPopover: function () {
+    this.setState({bottomLeftModalPopoverOpen: false});
   },
 
   _getBottomLeftButton: function () {
@@ -60,6 +70,16 @@ var DemoPopoverSection = React.createClass({
                 <td>
                   <Button id='bottom-left-button-id' ref='bottomLeftButton' onClick={function () {this.setState({bottomLeftPopoverOpen: true});}.bind(this)}>Bottom Left</Button>
                   <DemoPopover placement='bottom-left' target={this._getBottomLeftButton} isOpen={this.state.bottomLeftPopoverOpen} onRequestClose={this._shouldCloseBottomLeftPopover}/>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <Button id='bottom-right-function-button-id' onClick={function () {this.setState({bottomRightFunctionPopoverOpen: true});}.bind(this)}>Bottom Right Function</Button>
+                  <DemoPopover placement='bottom-right' target={function () { return document.getElementById('bottom-right-function-button-id');} } isOpen={this.state.bottomRightFunctionPopoverOpen} onRequestClose={this._shouldCloseBottomRightFunctionPopover}/>
+                </td>
+                <td>
+                  <Button id='bottom-left-modal-button-id' onClick={function () {this.setState({bottomLeftModalPopoverOpen: true});}.bind(this)}>Modal</Button>
+                  <DemoPopover placement='center' target={function () { return document.body; } } isOpen={this.state.bottomLeftModalPopoverOpen} onRequestClose={this._shouldCloseBottomLeftModalPopover}/>
                 </td>
               </tr>
             </tbody>

--- a/src/Popover.jsx
+++ b/src/Popover.jsx
@@ -5,7 +5,7 @@ var PopoverBackground = require('./PopoverBackground');
 var Popover = React.createClass({
 
   propTypes: {
-    placement: React.PropTypes.oneOf(['right', 'bottom-right', 'left', 'bottom-left']),
+    placement: React.PropTypes.oneOf(['right', 'bottom-right', 'left', 'bottom-left', 'center']),
     isOpen: React.PropTypes.bool,
     onRequestClose: React.PropTypes.func,
     target: React.PropTypes.oneOfType([
@@ -137,6 +137,13 @@ var Popover = React.createClass({
           attachment: 'top left',
           targetAttachment: 'middle right',
           offset: '38px -20px'
+        };
+        break;
+      case 'center':
+        tetherConfig = {
+          attachment: 'middle center',
+          targetAttachment: 'middle center',
+          targetModifier: 'visible'
         };
         break;
       default:

--- a/src/Popover.jsx
+++ b/src/Popover.jsx
@@ -11,7 +11,8 @@ var Popover = React.createClass({
     target: React.PropTypes.oneOfType([
       React.PropTypes.string,
       React.PropTypes.instanceOf(Function)
-    ])
+    ]),
+    offset: React.PropTypes.string
   },
 
   getDefaultProps: function () {
@@ -146,6 +147,9 @@ var Popover = React.createClass({
         };
     }
 
+    if (this.props.offset) {
+      tetherConfig.offset = this.props.offset;
+    }
     tetherConfig.element = React.findDOMNode(this._containerDiv);
     tetherConfig.target = this._getTarget();
     return tetherConfig;

--- a/src/Popover.jsx
+++ b/src/Popover.jsx
@@ -8,7 +8,10 @@ var Popover = React.createClass({
     placement: React.PropTypes.oneOf(['right', 'bottom-right', 'left', 'bottom-left']),
     isOpen: React.PropTypes.bool,
     onRequestClose: React.PropTypes.func,
-    target: React.PropTypes.string
+    target: React.PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.instanceOf(Function)
+    ])
   },
 
   getDefaultProps: function () {
@@ -144,8 +147,20 @@ var Popover = React.createClass({
     }
 
     tetherConfig.element = React.findDOMNode(this._containerDiv);
-    tetherConfig.target = document.getElementById(this.props.target);
+    tetherConfig.target = this._getTarget();
     return tetherConfig;
+  },
+
+  _getTarget: function () {
+    var target;
+
+    target = this.props.target;
+
+    if (target instanceof Function) {
+      return this.props.target();
+    }
+
+    return document.getElementById(target);
   },
 
   _listenForEscapePress: function () {

--- a/src/PopoverOverlay.jsx
+++ b/src/PopoverOverlay.jsx
@@ -3,7 +3,7 @@ var React = require('react');
 var PopoverOverlay = React.createClass({
 
   propTypes: {
-    placement: React.PropTypes.oneOf(['right', 'bottom-right', 'left', 'bottom-left'])
+    placement: React.PropTypes.oneOf(['right', 'bottom-right', 'left', 'bottom-left', 'center'])
   },
 
   getDefaultProps: function () {
@@ -28,15 +28,29 @@ var PopoverOverlay = React.createClass({
     return arrowClasses.join(' ');
   },
 
+  _shouldShowArrow: function () {
+    return this.props.placement !== 'center';
+  },
+
   render: function () {
-    return (
-      <div className={this.props.className}>
-        <div className={this._arrowPlacement()}></div>
-        <div className='rs-popover-content'>
-          {this.props.children}
+    if (this._shouldShowArrow()) {
+      return (
+        <div className={this.props.className}>
+          <div className={this._arrowPlacement()}></div>
+          <div className='rs-popover-content'>
+            {this.props.children}
+          </div>
         </div>
-      </div>
-    );
+      );
+    } else {
+      return (
+        <div className={this.props.className}>
+          <div className='rs-popover-content'>
+            {this.props.children}
+          </div>
+        </div>
+      );
+    }
   }
 });
 

--- a/test/PopoverOverlaySpec.jsx
+++ b/test/PopoverOverlaySpec.jsx
@@ -70,5 +70,11 @@ describe('PopoverOverlay', function () {
 
       expect(arrow()).toHaveClass('rs-popover-arrow-top-right');
     });
+
+    it('is not rendered with center placement', function () {
+      renderPopover('center');
+
+      expect(TestUtils.scryRenderedDOMComponentsWithClass(popover, 'rs-popover-arrow').length).toBe(0);
+    });
   });
 });

--- a/test/PopoverSpec.jsx
+++ b/test/PopoverSpec.jsx
@@ -8,15 +8,22 @@ var TestUtils = React.addons.TestUtils;
 describe('Popover', function () {
   var popover, tether, requestCloseCallback;
 
-  function renderPopover(placement, isOpen) {
+  function renderPopover(placement, isOpen, useTargetCallback) {
+    var target;
+
     setFixtures('<div id="content"><div id="some-element-id">The Target</div><div id="container"></div></div>');
 
     requestCloseCallback = jasmine.createSpy('requestCloseCallback');
     tether = jasmine.createSpyObj('tether', ['destroy']);
     spyOn(Popover.prototype.__reactAutoBindMap, '_createTether').andReturn(tether);
 
+    if (useTargetCallback) {
+      target = function () { return document.getElementById('some-element-id'); };
+    } else {
+      target = 'some-element-id';
+    }
     popover = React.render(
-      <Popover placement={placement} isOpen={isOpen} onRequestClose={requestCloseCallback} target='some-element-id'>
+      <Popover placement={placement} isOpen={isOpen} onRequestClose={requestCloseCallback} target={target}>
         <PopoverOverlay>
           This is the popover content
         </PopoverOverlay>
@@ -89,6 +96,18 @@ describe('Popover', function () {
 
     it('to the bottom left of the target', function () {
       renderPopover('bottom-left', true);
+
+      expect(Popover.prototype.__reactAutoBindMap._createTether).toHaveBeenCalledWith({
+        element: React.findDOMNode(popover._containerDiv),
+        target: React.findDOMNode(document.getElementById('some-element-id')),
+        attachment: 'top right',
+        targetAttachment: 'bottom left',
+        offset: '-20px -45px'
+      });
+    });
+
+    it('renders with a target function', function () {
+      renderPopover('bottom-left', true, true);
 
       expect(Popover.prototype.__reactAutoBindMap._createTether).toHaveBeenCalledWith({
         element: React.findDOMNode(popover._containerDiv),

--- a/test/PopoverSpec.jsx
+++ b/test/PopoverSpec.jsx
@@ -8,7 +8,7 @@ var TestUtils = React.addons.TestUtils;
 describe('Popover', function () {
   var popover, tether, requestCloseCallback;
 
-  function renderPopover(placement, isOpen, useTargetCallback) {
+  function renderPopover(placement, isOpen, useTargetCallback, offset) {
     var target;
 
     setFixtures('<div id="content"><div id="some-element-id">The Target</div><div id="container"></div></div>');
@@ -22,8 +22,9 @@ describe('Popover', function () {
     } else {
       target = 'some-element-id';
     }
+
     popover = React.render(
-      <Popover placement={placement} isOpen={isOpen} onRequestClose={requestCloseCallback} target={target}>
+      <Popover placement={placement} isOpen={isOpen} onRequestClose={requestCloseCallback} target={target} offset={offset}>
         <PopoverOverlay>
           This is the popover content
         </PopoverOverlay>
@@ -115,6 +116,18 @@ describe('Popover', function () {
         attachment: 'top right',
         targetAttachment: 'bottom left',
         offset: '-20px -45px'
+      });
+    });
+
+    it('can override the offsets', function () {
+      renderPopover('bottom-left', true, false, '10px 10px');
+
+      expect(Popover.prototype.__reactAutoBindMap._createTether).toHaveBeenCalledWith({
+        element: React.findDOMNode(popover._containerDiv),
+        target: React.findDOMNode(document.getElementById('some-element-id')),
+        attachment: 'top right',
+        targetAttachment: 'bottom left',
+        offset: '10px 10px'
       });
     });
   });

--- a/test/PopoverSpec.jsx
+++ b/test/PopoverSpec.jsx
@@ -130,6 +130,18 @@ describe('Popover', function () {
         offset: '10px 10px'
       });
     });
+
+    it('on the center of the target', function () {
+      renderPopover('center', true);
+
+      expect(Popover.prototype.__reactAutoBindMap._createTether).toHaveBeenCalledWith({
+        element: React.findDOMNode(popover._containerDiv),
+        target: React.findDOMNode(document.getElementById('some-element-id')),
+        attachment: 'middle center',
+        targetAttachment: 'middle center',
+        targetModifier: 'visible'
+      });
+    });
   });
 
   describe('notifies parent of close request', function () {


### PR DESCRIPTION
Changes in this PR:

1. All users to override the offset of a popover
2. `target` can be a string ID or a function that returns the target element
3. `center` placement property. This will place the popover over the center of the target with no arrow rendered. This will be useful for modal like behavior where the popover should be placed over the center of the document body.