### PR TITLE
Allow additional classes on the popover footer

### DIFF
--- a/src/PopoverFooter.jsx
+++ b/src/PopoverFooter.jsx
@@ -5,8 +5,11 @@ import ButtonGroup from './ButtonGroup';
 class PopoverFooter extends React.Component {
 
   render () {
+    var classes;
+
+    classes = ['rs-popover-footer', this.props.className];
     return (
-      <ButtonGroup className='rs-popover-footer'>
+      <ButtonGroup className={classes.join(' ')}>
         {this.props.children}
       </ButtonGroup>
     );

--- a/test/PopoverFooterSpec.jsx
+++ b/test/PopoverFooterSpec.jsx
@@ -26,6 +26,18 @@ describe('PopoverFooter', () => {
     expect(React.findDOMNode(buttonGroup)).toHaveClass('rs-btn-group');
   });
 
+  it('renders additional classes', () => {
+    var newFooter, buttonGroup;
+
+    newFooter = TestUtils.renderIntoDocument(
+      <PopoverFooter className="second-class">Hello</PopoverFooter>
+    );
+    buttonGroup = TestUtils.findRenderedDOMComponentWithClass(newFooter, 'rs-popover-footer');
+
+    expect(React.findDOMNode(buttonGroup)).toHaveClass('rs-btn-group');
+    expect(React.findDOMNode(buttonGroup)).toHaveClass('second-class');
+  });
+
   it('renders children', () => {
     expect(React.findDOMNode(popoverFooter).textContent).toBe('Hello');
   });


### PR DESCRIPTION
We need this in Reach because our tests expect the button group to have "save-cancel" on it, and more generally because all components should be able to have arbitrary extra classes where needed.