### PR TITLE
chore(release): v 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Version 0.5.0
+1. Allow `PopoverFooter` to receive additional class names as a property.
+
 ### Version 0.4.0
 1. Dropdowns
 2. `action` type for Buttons to create Action Buttons (with cog and caret icons)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "canon-react",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Rackspace Canon components built with React",
   "repository": {
     "type": "git",


### PR DESCRIPTION
releasing version 0.5.0
1. Allow PopoverFooter to receive additional class names as a property