### PR TITLE
fix(popover): reposition popover after render

### DIFF
--- a/demo/DemoPopover.jsx
+++ b/demo/DemoPopover.jsx
@@ -22,7 +22,7 @@ var DemoPopover = React.createClass({
               <div className='rs-control-group'>
                 <label className='rs-control-label'>Field 1</label>
                 <div className='rs-controls'>
-                  <input type='text'/>
+                  <input autoFocus type='text'/>
                 </div>
               </div>
             </form>

--- a/src/Popover.jsx
+++ b/src/Popover.jsx
@@ -79,6 +79,9 @@ class Popover extends React.Component {
     React.render(<PopoverBackground onRequestClose={this.props.onRequestClose} />, this._backgroundDiv);
     this._containerDiv.className += ' rs-popover';
 
+    if (!this._tether) {
+      this._tether = this._createTether(this._getTetherConfig());
+    }
     popover = React.cloneElement(
       React.Children.only(this.props.children),
       {
@@ -86,9 +89,7 @@ class Popover extends React.Component {
       }
     );
     this._popoverNode = React.render(popover, this._containerDiv);
-    if (!this._tether) {
-      this._tether = this._createTether(this._getTetherConfig());
-    }
+    this._tether.position();
   }
 
   // This is a seam for testing

--- a/test/PopoverSpec.jsx
+++ b/test/PopoverSpec.jsx
@@ -15,7 +15,7 @@ describe('Popover', () => {
       closeCallBackCalled = true;
       return e;
     };
-    tether = jasmine.createSpyObj('tether', ['destroy']);
+    tether = jasmine.createSpyObj('tether', ['destroy', 'position']);
     spyOn(Popover.prototype, '_createTether').andReturn(tether);
 
     if (useTargetCallback) {
@@ -47,6 +47,12 @@ describe('Popover', () => {
     renderPopover('right', false);
 
     expect(popover._popoverNode).toEqual(null);
+  });
+
+  it('repositions the tether', () => {
+    renderPopover('right', true);
+
+    expect(tether.position).toHaveBeenCalled();
   });
 
   it('renders the popover overlay', () => {


### PR DESCRIPTION
Create the tether before the popover content is rendered, and manually trigger a tether reposition after the popover has been rendered. This fixes an issue where autofocused controls cause bad scrolling behavior; previously, the popover content would be initially rendered in the wrong place and then quickly repositioned, causing autofocus to scroll to the wrong place (typically, to the bottom of the page). This fixes that behavior and makes the popover component compatible with autofocus.