### PR TITLE
feat(PopoverBody): allow additional classNames on body

### DIFF
--- a/src/PopoverBody.jsx
+++ b/src/PopoverBody.jsx
@@ -3,8 +3,11 @@ import React from 'react';
 class PopoverBody extends React.Component {
 
   render() {
+    var classes;
+
+    classes = ['rs-popover-body', this.props.className];
     return (
-      <div className='rs-popover-body'>
+      <div className={classes.join(' ')}>
         {this.props.children}
       </div>
     );

--- a/test/PopoverBodySpec.jsx
+++ b/test/PopoverBodySpec.jsx
@@ -8,7 +8,7 @@ describe('PopoverBody', () => {
 
   beforeEach(() => {
     popoverBody = TestUtils.renderIntoDocument(
-      <PopoverBody>
+      <PopoverBody className="test-additional-class">
         Hello
       </PopoverBody>
     );
@@ -20,6 +20,10 @@ describe('PopoverBody', () => {
 
   it('renders a popover body', () => {
     expect(React.findDOMNode(popoverBody)).toHaveClass('rs-popover-body');
+  });
+
+  it('adds an additional class', () => {
+    expect(React.findDOMNode(popoverBody)).toHaveClass('test-additional-class');
   });
 
   it('renders children', () => {


### PR DESCRIPTION
Allow specification of additional popover body classNames via props. Previously there was no way to customize CSS classes on the body.