### PR TITLE
chore(release): v 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Version 0.6.0
+1. Allow `PopoverBody` to receive additional class names as a property.
+2. Fixed an issue where autoFocus would cause popovers to scroll out of view
+
 ### Version 0.5.0
 1. Allow `PopoverFooter` to receive additional class names as a property.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "canon-react",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Rackspace Canon components built with React",
   "repository": {
     "type": "git",


### PR DESCRIPTION
1. Allow PopoverBody to receive additional class names as a property.
2. Fixed an issue where autoFocus would cause popovers to scroll out of view