### PR TITLE
fix(propTypes): use accurate propTypes

### DIFF
--- a/src/ButtonGroup.jsx
+++ b/src/ButtonGroup.jsx
@@ -17,9 +17,4 @@ class ButtonGroup extends React.Component {
   }
 }
 
-ButtonGroup.propTypes = {
-  children: React.PropTypes.element.isRequired,
-  className: React.PropTypes.array
-};
-
 export default ButtonGroup;

--- a/src/PopoverBody.jsx
+++ b/src/PopoverBody.jsx
@@ -14,8 +14,4 @@ class PopoverBody extends React.Component {
   }
 }
 
-PopoverBody.propTypes = {
-  children: React.PropTypes.element.isRequired
-};
-
 export default PopoverBody;

--- a/src/PopoverFooter.jsx
+++ b/src/PopoverFooter.jsx
@@ -16,8 +16,4 @@ class PopoverFooter extends React.Component {
   }
 }
 
-PopoverFooter.propTypes = {
-  children: React.PropTypes.element.isRequired
-};
-
 export default PopoverFooter;

--- a/src/PopoverOverlay.jsx
+++ b/src/PopoverOverlay.jsx
@@ -45,8 +45,7 @@ class PopoverOverlay extends React.Component {
 }
 
 PopoverOverlay.propTypes = {
-  children: React.PropTypes.element.isRequired,
-  className: React.PropTypes.isRequired,
+  children: React.PropTypes.node.isRequired,
   placement: React.PropTypes.oneOf([
     'right', 'bottom-right', 'left', 'bottom-left', 'center'
   ])

--- a/src/StatusIndicator.jsx
+++ b/src/StatusIndicator.jsx
@@ -36,8 +36,6 @@ class StatusIndicator extends React.Component {
 }
 
 StatusIndicator.propTypes = {
-  children: React.PropTypes.element.isRequired,
-  className: React.PropTypes.array,
   status: React.PropTypes.oneOf(['ok', 'error', 'processing', 'warning', 'disabled']),
   hidden: React.PropTypes.bool
 };


### PR DESCRIPTION
Remove instances where 'children' is specified unnecessarily and 'className' is specified as an array rather than a string.