### PR TITLE
Contributing Enhancements and Guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Contributing
+
+If you have found an issue or would like to request a new feature, simply create a new issue detailing the request. We also welcome pull requests. See below for information on getting started with development and submitting pull requests.
+
+## Submitting a Pull Request
+If you wish to submit a pull request for a new feature or issue, you should start by forking this repository first. After you have forked and cloned the repository locally, create a new branch with a name that loosely describes the issue on which you will be working. Once you think you have the addressed the issue in question, submit a pull request. Here are some guidelines to follow when writing code for canon-react:
+
+- Commit messages should follow Angular's [Git Commit Guidelines](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#-git-commit-guidelines).
+- Intermediate and work-in-progress commits should be rebased out.
+- Keep pull requests tightly scoped to the issue or feature being addressed.
+- All changes from every developer must go through code review before they will be merged.
+- All changes must pass the CI build. Travis CI will automatically update your PR with the build status.
+- All changes must have unit tests.
+- All components must have a demo implementation in the `demo/` directory.
+
+## Development
+There are a few scripts in the `scripts/` directory to make developing in canon-react easy.
+### `scripts/setup`
+Run the `setup` script to install all dependencies needed to lint, build, test, and run the demo server.
+### `scripts/server`
+The `server` script will run a lightweight http server to server up react components in the `demo/` directory. This script will also watch for file changes while you are developing so you only need to refresh your browser to see your most recent changes. The demo web page can be viewed at `http://localhost:8080/demo/`.
+### `scripts/test`
+The `test` script will start a kara test runner that runs the entire suite of unit tests for this library and will stay alive and watch for file changes while you are developing.
+### `scripts/cibuild`
+The `cibuild` script is run by TravisCI for every pull request. This script runs linting, build tasks on the javascript, and unit tests. You can run this file locally to ensure your branch will pass on the CI environment. If you wish to run linting separately from these jobs, you can run `grunt lint`.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -54,9 +54,10 @@ module.exports = function (grunt) {
           'src/**/*.jsx',
           'src/**/*.js',
           'test/**/*.jsx',
-          'test/**/*.js'
+          'test/**/*.js',
+          'demo/**/*.jsx'
         ],
-        tasks: ['build'],
+        tasks: ['build-dev'],
         options: {
           spawn: false
         }
@@ -110,14 +111,25 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-browserify');
 
+  grunt.registerTask('build-dev', [
+    'clean:test',
+    'clean:transpiled',
+    'babel:src',
+    'babel:test',
+    'babel:demo',
+    'browserify:test',
+    'browserify:demo'
+  ]);
+
   grunt.registerTask('build', [
     'clean:test',
-    'eslint',
+    'clean:transpiled',
+    'lint:eslint',
     'babel:src',
     'babel:test',
     'browserify:test',
     'browserify:release',
-    'uglify:build',
+    'uglify:build'
   ]);
 
   grunt.registerTask('demo-build', [

--- a/README.md
+++ b/README.md
@@ -6,16 +6,13 @@ CAUTION: This library is not ready for public use yet.
 # canon-react
 React components for Rackspace's Canon framework
 
-## Instructions For Devs
-Git clone and run `npm install` to install dependencies (may need to be run as sudo)
+## Contributing
+For issues or feature requests please submit an [issue](https://github.com/rackerlabs/canon-react/issues). For more information on contributing to canon-react, checkout the [Contributing Guide](CONTRIBUTING.md)
 
-### Building
-To build a bundled file for release run `npm run build`
-To build a demo bundle for testing run `npm run demo-build` and open `canon-react/demo/index.html` in your browser
+## Building
+The latest stable release is available under the releases section of the repository. You can also generate a release from master if you wish to live on the edge.
 
-### Testing
-To run tests with phantom run `npm run test`
-To run tests in chrome and watch for changes run `npm run test-watch`
+To build a bundled file for release run `scripts/cibuild`
 
 ## Instructions For Including In Your Project
 `npm install canon-react` will install the canon-react module inside of the `node_modules` directory of your current directory. `npm install canon-react -g` (may need sudo) will install the canon-react module globally.
@@ -37,5 +34,5 @@ An example of how to use canon-react components can be found in `node_modules/ca
 
 # Roadmap
 This is a list of what is planned for the next release
-## v 0.5.0
-??? What would you like [see](https://github.com/rackerlabs/canon-react/issues/new)?
+## v 1.0.0
+??? What would you like to [see](https://github.com/rackerlabs/canon-react/issues/new)?

--- a/package.json
+++ b/package.json
@@ -8,12 +8,9 @@
   },
   "scripts": {
     "prepublish": "./prepublish.sh",
-    "build": "./node_modules/.bin/grunt build",
+    "build": "scripts/cibuild",
     "clean": "./node_modules/.bin/grunt clean",
-    "demo-build": "./node_modules/.bin/grunt demo-build",
-    "test-watch": "./node_modules/.bin/grunt watch 2>&1 >/dev/null & ./node_modules/karma/bin/karma start karma.dev.js",
-    "test": "./node_modules/.bin/grunt build && ./node_modules/karma/bin/karma start karma.ci.js",
-    "lint": "./node_modules/.bin/grunt lint"
+    "test": "scripts/cibuild"
   },
   "keywords": [
     "react",
@@ -68,6 +65,7 @@
     "grunt-eslint": "^15.0.0",
     "grunt-jsxhint": "~0.5.0",
     "grunt-shell": "~0.6.4",
+    "http-server": "^0.8.5",
     "karma": "^0.12.22",
     "karma-browserify": "~3.0.1",
     "karma-chrome-launcher": "^0.1.4",

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# script/cibuild: Run all build and test tasks for continuous integration
+
+./node_modules/.bin/grunt build && ./node_modules/karma/bin/karma start karma.ci.js

--- a/scripts/server
+++ b/scripts/server
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# script/server: Run a development server and watch for file changes while building demo components
+
+script/update
+
+./node_modules/.bin/grunt watch & node node_modules/.bin/http-server

--- a/scripts/setup
+++ b/scripts/setup
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# script/bootstrap: Resolve all dependencies required to develop and test canon-react components
+
+sudo npm install

--- a/scripts/test
+++ b/scripts/test
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# script/test: Run the suite of tests for the application. Will watch for file changes to continuously run tests during development.
+
+./node_modules/.bin/grunt watch & ./node_modules/karma/bin/karma start karma.dev.js

--- a/scripts/update
+++ b/scripts/update
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# script/update: Resolve all dependencies required to develop and test canon-react components
+
+sudo npm install


### PR DESCRIPTION
Added contributing guidelines.

Created scripts for running various development tasks that follow github's script guidelines for easier setup and development:
scripts/cibuild - runs lint, build, and test for CI server
scripts/server - starts an http server to serve up demo components; also watches for file changes
scripts/setup - installs all dependencies needed for development
scripts/test - starts karma to run unit tests; watches for file changes
scripts/update - can be run after pulling in master to get latest dependencies