### PR TITLE
Make clicks on dropdown items close the dropdown

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,6 @@ Run the `setup` script to install all dependencies needed to lint, build, test, 
 ### `scripts/server`
 The `server` script will run a lightweight http server to server up react components in the `demo/` directory. This script will also watch for file changes while you are developing so you only need to refresh your browser to see your most recent changes. The demo web page can be viewed at `http://localhost:8080/demo/`.
 ### `scripts/test`
-The `test` script will start a kara test runner that runs the entire suite of unit tests for this library and will stay alive and watch for file changes while you are developing.
+The `test` script will start a karma test runner that runs the entire suite of unit tests for this library and will stay alive and watch for file changes while you are developing.
 ### `scripts/cibuild`
 The `cibuild` script is run by TravisCI for every pull request. This script runs linting, build tasks on the javascript, and unit tests. You can run this file locally to ensure your branch will pass on the CI environment. If you wish to run linting separately from these jobs, you can run `grunt lint`.

--- a/demo/DemoActionMenu.jsx
+++ b/demo/DemoActionMenu.jsx
@@ -6,7 +6,7 @@ import DropdownItem from './DropdownItem';
 class DemoActionMenu extends React.Component {
   render() {
     return (
-      <Dropdown type='action'>
+      <Dropdown { ...this.props } type='action'>
         <DropdownItem type='category'>Identify</DropdownItem>
         <DropdownItem type='link'>Rename Server...</DropdownItem>
         <DropdownItem type='link'>Tag Server...</DropdownItem>

--- a/demo/DemoPrimaryDropdown.jsx
+++ b/demo/DemoPrimaryDropdown.jsx
@@ -6,7 +6,7 @@ import DropdownItem from './DropdownItem';
 class DemoPrimaryDropdown extends React.Component {
   render() {
     return (
-      <Dropdown type='primary'>
+      <Dropdown { ...this.props } type='primary'>
         <DropdownItem type='category'>Infrastructure</DropdownItem>
         <DropdownItem type='link'>Servers</DropdownItem>
         <DropdownItem type='link'>Load Balancers</DropdownItem>

--- a/demo/DemoUtilityDropdown.jsx
+++ b/demo/DemoUtilityDropdown.jsx
@@ -7,7 +7,7 @@ import DropdownItem from './DropdownItem';
 class DemoUtilityDropdown extends React.Component {
   render() {
     return (
-      <Dropdown type='utility'>
+      <Dropdown { ...this.props } type='utility'>
         <DropdownItem type='text'>Account# 1234567</DropdownItem>
         <Divider/>
         <DropdownItem type='link'>Billing</DropdownItem>

--- a/src/Dropdown.jsx
+++ b/src/Dropdown.jsx
@@ -4,14 +4,20 @@ class Dropdown extends React.Component {
   render() {
     let style;
 
-    style = {float: 'left'};
+    style = { float: 'left' };
     return (
       <div className={this._classes()} style={style}>
         <ul className='rs-dropdown-menu visible'>
-          {this.props.children}
+          { this._children() }
         </ul>
       </div>
     );
+  }
+
+  _children() {
+    return React.Children.map(this.props.children, (child) => {
+      return React.cloneElement(child, { hideCallback: this.props.hideCallback });
+    });
   }
 
   _classes() {
@@ -35,7 +41,8 @@ class Dropdown extends React.Component {
 }
 
 Dropdown.propTypes = {
-  type: React.PropTypes.oneOf(['primary', 'utility', 'action'])
+  type: React.PropTypes.oneOf(['primary', 'utility', 'action']),
+  hideCallback: React.PropTypes.func.isRequired
 };
 
 Dropdown.defaultProps = {

--- a/src/DropdownItem.jsx
+++ b/src/DropdownItem.jsx
@@ -41,6 +41,7 @@ class DropdownItem extends React.Component {
   _handleClick(e) {
     if (this.props.enabled) {
       this.props.onClick(e);
+      this.props.hideCallback();
       return e;
     }
     e.preventDefault();
@@ -50,12 +51,14 @@ class DropdownItem extends React.Component {
 DropdownItem.propTypes = {
   enabled: React.PropTypes.bool,
   onClick: React.PropTypes.func,
+  hideCallback: React.PropTypes.func,
   type: React.PropTypes.oneOf(['link', 'category', 'text'])
 };
 
 DropdownItem.defaultProps = {
   enabled: true,
   onClick: function () {},
+  hideCallback: function () {},
   type: 'link'
 };
 

--- a/src/DropdownTrigger.jsx
+++ b/src/DropdownTrigger.jsx
@@ -81,7 +81,7 @@ class DropdownTrigger extends React.Component {
     dropdown = React.cloneElement(
       this.props.dropdown,
       {
-        hideCallback: this._hide
+        hideCallback: this._hide.bind(this)
       }
     );
 

--- a/test/DropdownItemSpec.jsx
+++ b/test/DropdownItemSpec.jsx
@@ -3,13 +3,18 @@ import React from 'react/addons';
 let TestUtils = React.addons.TestUtils;
 
 describe('DropdownItem', () => {
-  var dropdownItem, clickFunction;
+  var dropdownItem, clickFunction, hideFunction;
 
   beforeEach(() => {
     clickFunction = jasmine.createSpy('clickFunction');
+    hideFunction = jasmine.createSpy('hideFunction');
 
     dropdownItem = TestUtils.renderIntoDocument(
-      <DropdownItem id='dropdown-id' className='test-dropdown-class' onClick={clickFunction}>Dropdown Text</DropdownItem>
+      <DropdownItem
+        id='dropdown-id'
+        className='test-dropdown-class'
+        onClick={clickFunction}
+        hideCallback={hideFunction}>Dropdown Text</DropdownItem>
     );
   });
 
@@ -47,6 +52,12 @@ describe('DropdownItem', () => {
     TestUtils.Simulate.click(React.findDOMNode(dropdownItem));
 
     expect(clickFunction).toHaveBeenCalled();
+  });
+
+  it('executes the hide callback when clicked', () => {
+    TestUtils.Simulate.click(React.findDOMNode(dropdownItem));
+
+    expect(hideFunction).toHaveBeenCalled();
   });
 
   describe('dropdown types', () => {

--- a/test/DropdownSpec.jsx
+++ b/test/DropdownSpec.jsx
@@ -1,13 +1,16 @@
 import Dropdown from '../transpiled/Dropdown';
+import DropdownItem from '../transpiled/DropdownItem';
 import React from 'react/addons';
 let TestUtils = React.addons.TestUtils;
 
 describe('Dropdown', () => {
-  var dropdown;
+  var dropdown, hideFunction;
 
   beforeEach(() => {
+    hideFunction = jasmine.createSpy('hideFunction');
+
     dropdown = TestUtils.renderIntoDocument(
-      <Dropdown className='test-dropdown-class' >Dropdown Text</Dropdown>
+      <Dropdown className='test-dropdown-class' hideCallback={hideFunction}><DropdownItem type='link'>Dropdown Item...</DropdownItem></Dropdown>
     );
   });
 
@@ -32,7 +35,16 @@ describe('Dropdown', () => {
 
     menu = TestUtils.findRenderedDOMComponentWithClass(dropdown, 'rs-dropdown-menu');
 
-    expect(React.findDOMNode(menu).textContent).toBe('Dropdown Text');
+    expect(React.findDOMNode(menu).textContent).toBe('Dropdown Item...');
+  });
+
+  it('passes hide callback down to dropdown items', () => {
+    var childItem;
+
+    childItem = TestUtils.findRenderedComponentWithType(dropdown, DropdownItem);
+    TestUtils.Simulate.click(React.findDOMNode(childItem));
+
+    expect(hideFunction).toHaveBeenCalled();
   });
 
   describe('dropdown types', () => {

--- a/test/DropdownTriggerSpec.jsx
+++ b/test/DropdownTriggerSpec.jsx
@@ -2,6 +2,7 @@ import DropdownTrigger from '../transpiled/DropdownTrigger';
 
 import Button from '../transpiled/Button';
 import Dropdown from '../transpiled/Dropdown';
+import DropdownItem from '../transpiled/DropdownItem';
 import React from 'react/addons';
 let TestUtils = React.addons.TestUtils;
 
@@ -10,7 +11,7 @@ describe('DropdownTrigger', () => {
 
   const renderDropdown = () => {
     dropdownTrigger = TestUtils.renderIntoDocument(
-      <DropdownTrigger dropdown={<Dropdown><Button onClick={() => {}}>Hello</Button>Content</Dropdown>}>
+      <DropdownTrigger dropdown={<Dropdown><DropdownItem id='test-dropdown-item'>Hello</DropdownItem></Dropdown>}>
         <Button>Hello</Button>
       </DropdownTrigger>
     );
@@ -103,17 +104,14 @@ describe('DropdownTrigger', () => {
         expect(dropdownTrigger._dropdownNode).toBeNull();
       });
 
-      it('does not hide the dropdown when clicking inside of the dropdown', () => {
-        var dropdownButton;
-
-        renderDropdown('right');
+      it('hides the dropdown when a dropdown item is clicked', () => {
+        renderDropdown();
         clickTrigger();
 
-        dropdownButton = TestUtils.findRenderedComponentWithType(dropdownTrigger._dropdownNode, Button);
-        TestUtils.Simulate.click(React.findDOMNode(dropdownButton));
+        TestUtils.Simulate.click(document.getElementById('test-dropdown-item'));
 
-        expect(tether.destroy).not.toHaveBeenCalled();
-        expect(dropdownTrigger._dropdownNode).not.toBeNull();
+        expect(tether.destroy).toHaveBeenCalled();
+        expect(dropdownTrigger._dropdownNode).toBeNull();
       });
     });
   });


### PR DESCRIPTION
With the current implementation of dropdowns there is no way to hide the dropdown itself after clicking on an item of the dropdown. The desired behavior is that the dropdown should be hidden after it is clicked so a popover/navigation/some action can occur without the dropdown still being visible.