### PR TITLE
fix(Button): Fix HTML type of Button

### DIFF
--- a/src/Button.jsx
+++ b/src/Button.jsx
@@ -15,7 +15,15 @@ const BUTTON_TYPES = {
 
 class Button extends React.Component {
   render() {
-    let classes;
+    let classes, propsWithHTMLType;
+
+    propsWithHTMLType = Object.assign({}, this.props);
+    delete propsWithHTMLType.type;
+    if(['primary', 'login'].indexOf(this.props.type) !== -1) {
+      propsWithHTMLType.type = 'submit';
+    } else {
+      propsWithHTMLType.type = 'button';
+    }
 
     classes = classNames(
       this.props.className,
@@ -26,14 +34,14 @@ class Button extends React.Component {
 
     if (this.props.type === 'action') {
       return (
-        <button {...this.props} className={classes} onClick={this._handleClick.bind(this)}>
+        <button {...propsWithHTMLType} className={classes} onClick={this._handleClick.bind(this)}>
           <span className='rs-cog'></span> {this.props.children} <span className='rs-caret'></span>
         </button>
       );
     }
 
     return (
-      <button {...this.props} className={classes} onClick={this._handleClick.bind(this)}>
+      <button {...propsWithHTMLType} className={classes} onClick={this._handleClick.bind(this)}>
         {this.props.children}
       </button>
     );

--- a/test/ButtonSpec.jsx
+++ b/test/ButtonSpec.jsx
@@ -81,12 +81,14 @@ describe('Button', () => {
 
       expect(React.findDOMNode(button)).toHaveClass('rs-btn');
       expect(React.findDOMNode(button)).toHaveClass('rs-btn-primary');
+      expect(React.findDOMNode(button).getAttribute('type')).toBe('submit');
     });
 
     it('secondary', () => {
       renderButton('secondary');
 
       expect(React.findDOMNode(button)).toHaveClass('rs-btn');
+      expect(React.findDOMNode(button).getAttribute('type')).toBe('button');
     });
 
     it('link', () => {
@@ -94,6 +96,7 @@ describe('Button', () => {
 
       expect(React.findDOMNode(button)).toHaveClass('rs-btn');
       expect(React.findDOMNode(button)).toHaveClass('rs-btn-link');
+      expect(React.findDOMNode(button).getAttribute('type')).toBe('button');
     });
 
     it('login', () => {
@@ -101,30 +104,35 @@ describe('Button', () => {
 
       expect(React.findDOMNode(button)).toHaveClass('rs-btn');
       expect(React.findDOMNode(button)).toHaveClass('rs-btn-login');
+      expect(React.findDOMNode(button).getAttribute('type')).toBe('submit');
     });
 
     it('cog', () => {
       renderButton('cog');
 
       expect(React.findDOMNode(button)).toHaveClass('rs-cog');
+      expect(React.findDOMNode(button).getAttribute('type')).toBe('button');
     });
 
     it('delete', () => {
       renderButton('delete');
 
       expect(React.findDOMNode(button)).toHaveClass('rs-delete');
+      expect(React.findDOMNode(button).getAttribute('type')).toBe('button');
     });
 
     it('edit', () => {
       renderButton('edit');
 
       expect(React.findDOMNode(button)).toHaveClass('rs-edit');
+      expect(React.findDOMNode(button).getAttribute('type')).toBe('button');
     });
 
     it('plus', () => {
       renderButton('plus');
 
       expect(React.findDOMNode(button)).toHaveClass('rs-plus');
+      expect(React.findDOMNode(button).getAttribute('type')).toBe('button');
     });
   });
 


### PR DESCRIPTION
There are only three permissible types for an html button - 'submit',
'reset' and 'button'. Any other type is treated as a 'submit' type. This
leads to unexpected behavior when using a non-submit button inside a
form (Hitting enter triggers the onClick handler of the non-submit
button). The correct behavior would be to set the type to 'button' in
this case and to 'submit' only when the button is intended as the
primary button of a form.

This fixes #81