### PR TITLE
fix(Button): Fix HTML type of Button

### DIFF
--- a/demo/DemoButtonGroupSection.jsx
+++ b/demo/DemoButtonGroupSection.jsx
@@ -13,18 +13,18 @@ class DemoButtonGroupSection extends React.Component {
         </div>
         <div className='rs-detail-section-body'>
           <ButtonGroup>
-            <Button type='primary' enabled={true}>Primary</Button>
-            <Button type='secondary' enabled={true}>Secondary</Button>
-            <Button type='link' enabled={true}>Cancel</Button>
+            <Button canonStyle='primary' enabled={true}>Primary</Button>
+            <Button canonStyle='secondary' enabled={true}>Secondary</Button>
+            <Button canonStyle='link' enabled={true}>Cancel</Button>
             <ProcessingIndicator/>
           </ButtonGroup>
         </div>
         <div className='rs-detail-section-body'>
           <h3>Submitting State</h3>
           <ButtonGroup>
-            <Button type='primary' enabled={false}>Primary</Button>
-            <Button type='secondary' enabled={false}>Secondary</Button>
-            <Button type='link' enabled={false} hidden={true}>Cancel</Button>
+            <Button canonStyle='primary' enabled={false}>Primary</Button>
+            <Button canonStyle='secondary' enabled={false}>Secondary</Button>
+            <Button canonStyle='link' enabled={false} hidden={true}>Cancel</Button>
             <ProcessingIndicator hidden={false}/>
           </ButtonGroup>
         </div>

--- a/demo/DemoButtonSection.jsx
+++ b/demo/DemoButtonSection.jsx
@@ -22,59 +22,59 @@ class DemoButtonSection extends React.Component {
             <tbody>
               <tr>
                 <td>
-                  <Button type='primary'>Primary</Button>
+                  <Button canonStyle='primary'>Primary</Button>
                 </td>
                 <td>Primary</td>
-                <td><pre><code>{"<Button type='primary'>Primary</Button>"}</code></pre></td>
+                <td><pre><code>{"<Button canonStyle='primary'>Primary</Button>"}</code></pre></td>
               </tr>
               <tr>
                 <td>
-                  <Button type='secondary'>Secondary</Button>
+                  <Button canonStyle='secondary'>Secondary</Button>
                 </td>
                 <td>Secondary</td>
-                <td><pre><code>{"<Button type='secondary'>Secondary</Button>"}</code></pre></td>
+                <td><pre><code>{"<Button canonStyle='secondary'>Secondary</Button>"}</code></pre></td>
               </tr>
               <tr>
                 <td>
-                  <Button type='login'>Login</Button>
+                  <Button canonStyle='login'>Login</Button>
                 </td>
                 <td>Login</td>
-                <td><pre><code>{"<Button type='login'>Login</Button>"}</code></pre></td>
+                <td><pre><code>{"<Button canonStyle='login'>Login</Button>"}</code></pre></td>
               </tr>
               <tr>
                 <td>
-                  <Button type='link'>Cancel</Button>
+                  <Button canonStyle='link'>Cancel</Button>
                 </td>
                 <td>Link</td>
-                <td><pre><code>{"<Button type='link'>Cancel</Button>"}</code></pre></td>
+                <td><pre><code>{"<Button canonStyle='link'>Cancel</Button>"}</code></pre></td>
               </tr>
               <tr>
                 <td>
-                  <Button type='delete'>Delete</Button>
+                  <Button canonStyle='delete'>Delete</Button>
                 </td>
                 <td>Delete</td>
-                <td><pre><code>{"<Button type='delete'>Delete</Button>"}</code></pre></td>
+                <td><pre><code>{"<Button canonStyle='delete'>Delete</Button>"}</code></pre></td>
               </tr>
               <tr>
                 <td>
-                  <Button type='edit'>Edit</Button>
+                  <Button canonStyle='edit'>Edit</Button>
                 </td>
                 <td>Edit</td>
-                <td><pre><code>{"<Button type='edit'>Edit</Button>"}</code></pre></td>
+                <td><pre><code>{"<Button canonStyle='edit'>Edit</Button>"}</code></pre></td>
               </tr>
               <tr>
                 <td>
-                  <Button type='plus'>Plus</Button>
+                  <Button canonStyle='plus'>Plus</Button>
                 </td>
                 <td>Plus</td>
-                <td><pre><code>{"<Button type='plus'>Plus</Button>"}</code></pre></td>
+                <td><pre><code>{"<Button canonStyle='plus'>Plus</Button>"}</code></pre></td>
               </tr>
               <tr>
                 <td>
-                  <Button type='action'>Actions</Button>
+                  <Button canonStyle='action'>Actions</Button>
                 </td>
                 <td>Action</td>
-                <td><pre><code>{"<Button type='action'>Actions</Button>"}</code></pre></td>
+                <td><pre><code>{"<Button canonStyle='action'>Actions</Button>"}</code></pre></td>
               </tr>
             </tbody>
           </table>
@@ -92,38 +92,38 @@ class DemoButtonSection extends React.Component {
             <tbody>
               <tr>
                 <td>
-                  <Button type='primary' enabled={false}>Primary</Button>
+                  <Button canonStyle='primary' enabled={false}>Primary</Button>
                 </td>
                 <td>Primary</td>
-                <td><pre><code>{"<Button type='primary' enabled={false}>Primary</Button>"}</code></pre></td>
+                <td><pre><code>{"<Button canonStyle='primary' enabled={false}>Primary</Button>"}</code></pre></td>
               </tr>
               <tr>
                 <td>
-                  <Button type='secondary' enabled={false}>Secondary</Button>
+                  <Button canonStyle='secondary' enabled={false}>Secondary</Button>
                 </td>
                 <td>Secondary</td>
-                <td><pre><code>{"<Button type='secondary' enabled={false}>Secondary</Button>"}</code></pre></td>
+                <td><pre><code>{"<Button canonStyle='secondary' enabled={false}>Secondary</Button>"}</code></pre></td>
               </tr>
               <tr>
                 <td>
-                  <Button type='login' enabled={false}>Login</Button>
+                  <Button canonStyle='login' enabled={false}>Login</Button>
                 </td>
                 <td>Login</td>
-                <td><pre><code>{"<Button type='login' enabled={false}>Login</Button>"}</code></pre></td>
+                <td><pre><code>{"<Button canonStyle='login' enabled={false}>Login</Button>"}</code></pre></td>
               </tr>
               <tr>
                 <td>
-                  <Button type='link' enabled={false}>Cancel</Button>
+                  <Button canonStyle='link' enabled={false}>Cancel</Button>
                 </td>
                 <td>Link</td>
-                <td><pre><code>{"<Button type='link' enabled={false}>Cancel</Button>"}</code></pre></td>
+                <td><pre><code>{"<Button canonStyle='link' enabled={false}>Cancel</Button>"}</code></pre></td>
               </tr>
               <tr>
                 <td>
-                  <Button type='edit' enabled={false}>Edit</Button>
+                  <Button canonStyle='edit' enabled={false}>Edit</Button>
                 </td>
                 <td>Edit</td>
-                <td><pre><code>{"<Button type='edit' enabled={false}>Edit</Button>"}</code></pre></td>
+                <td><pre><code>{"<Button canonStyle='edit' enabled={false}>Edit</Button>"}</code></pre></td>
               </tr>
             </tbody>
           </table>

--- a/demo/DemoDropdownSection.jsx
+++ b/demo/DemoDropdownSection.jsx
@@ -23,7 +23,7 @@ class DemoDropdownSection extends React.Component {
               <Button>Utility Dropdown</Button>
             </DropdownTrigger>
             <DropdownTrigger dropdown={<DemoActionMenu/>}>
-              <Button type='action'>Actions</Button>
+              <Button canonStyle='action'>Actions</Button>
             </DropdownTrigger>
             <DropdownTrigger dropdown={<DemoActionMenu/>}>
               <div className="rs-cog rs-dropdown-toggle"></div>

--- a/demo/DemoPopover.jsx
+++ b/demo/DemoPopover.jsx
@@ -24,8 +24,8 @@ class DemoPopover extends React.Component {
             </form>
           </PopoverBody>
           <PopoverFooter>
-            <Button type='primary' onClick={this.props.onRequestClose}>Save</Button>
-            <Button type='link' onClick={this.props.onRequestClose}>Cancel</Button>
+            <Button canonStyle='primary' onClick={this.props.onRequestClose}>Save</Button>
+            <Button canonStyle='link' onClick={this.props.onRequestClose}>Cancel</Button>
             <ProcessingIndicator hidden={true} />
           </PopoverFooter>
         </PopoverOverlay>

--- a/src/Button.jsx
+++ b/src/Button.jsx
@@ -20,11 +20,11 @@ class Button extends React.Component {
     classes = classNames(
       this.props.className,
       { 'disabled': !this.props.enabled },
-      BUTTON_TYPES[this.props.type],
+      BUTTON_TYPES[this.props.canonStyle],
       { 'rs-hidden': this.props.hidden }
     );
 
-    if (this.props.type === 'action') {
+    if (this.props.canonStyle === 'action') {
       return (
         <button {...this.props} className={classes} onClick={this._handleClick.bind(this)}>
           <span className='rs-cog'></span> {this.props.children} <span className='rs-caret'></span>
@@ -51,7 +51,7 @@ class Button extends React.Component {
 Button.propTypes = {
   enabled: React.PropTypes.bool,
   onClick: React.PropTypes.func,
-  type: React.PropTypes.oneOf([
+  canonStyle: React.PropTypes.oneOf([
     'action',
     'primary',
     'link',
@@ -62,12 +62,13 @@ Button.propTypes = {
     'edit',
     'plus'
   ]),
-  hidden: React.PropTypes.bool
+  hidden: React.PropTypes.bool,
+  type: React.PropTypes.string
 };
 
 Button.defaultProps = {
   enabled: true,
-  type: 'secondary',
+  canonStyle: 'secondary',
   hidden: false
 };
 

--- a/test/ButtonSpec.jsx
+++ b/test/ButtonSpec.jsx
@@ -58,10 +58,10 @@ describe('Button', () => {
     expect(React.findDOMNode(button)).toHaveClass('rs-hidden');
   });
 
-  describe('button types', () => {
-    const renderButton = (type) => {
+  describe('button canonStyles', () => {
+    const renderButton = (canonStyle) => {
       button = TestUtils.renderIntoDocument(
-        <Button type={type}>Button Text</Button>
+        <Button canonStyle={canonStyle}>Button Text</Button>
       );
     };
 


### PR DESCRIPTION
There are only three permissible types for an html button - 'submit',
'reset' and 'button'. Any other type is treated as a 'submit' type. This
leads to unexpected behavior when using a non-submit button inside a
form (Hitting enter triggers the onClick handler of the non-submit
button). The correct behavior would be to set the type to 'button' in
this case and to 'submit' only when the button is intended as the
primary button of a form.
The button's type can now be set independently of the button's
canonStyle.

This fixes #81