### PR TITLE
chore(release): v 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Version 0.9.0
+1. BREAKING CHANGE: Upgrading to support react ~0.14.0. No functions that are marked as deprecated in React ~0.14.0 are used in this release.
+
 ### Version 0.8.0
 1. BREAKING CHANGE: Fix conflict with HTML button `type` property in `Button` component. New `Button` property is called `canonStyle`.
 2. Add `isModal` property to `Popover` that adds a 50% opaque background to body overlay element.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "canon-react",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Rackspace Canon components built with React",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release Notes:

BREAKING CHANGE: Upgrading to support react ~0.14.0. No functions that are marked as deprecated in React ~0.14.0 are used in this release.