### PR TITLE
fix(Facets): don't reference this.props in Facet constructor

### DIFF
--- a/src/Facet.jsx
+++ b/src/Facet.jsx
@@ -6,8 +6,9 @@ import FacetToggler from './FacetToggler';
 class Facet extends React.Component {
   constructor(props) {
     super(props);
+
     this.state = {
-      criteriaTruncated: this.props.truncationEnabled
+      criteriaTruncated: props.truncationEnabled
     };
   }
 


### PR DESCRIPTION
this.props is null in IE and that may be what is causing the Facets to break.  It could be that the props in general are null, either way there's no need to route though 'this' when we have the props as a param. 

edit:
tested on IE9, it works!