### PR TITLE
feat: optional tether prop for DropdownTrigger

### DIFF
--- a/demo/DemoDropdownSection.jsx
+++ b/demo/DemoDropdownSection.jsx
@@ -13,6 +13,7 @@ class DemoDropdownSection extends React.Component {
       <div className='rs-detail-section'>
         <div className='rs-detail-section-header'>
           <h2>Dropdowns</h2>
+          <div>The buttons on the left demonstrate the default alignment value of 'left', whereas the 'Action' button on the right demonstrates and alignment value of 'right'.</div>
         </div>
         <div className='rs-detail-section-body'>
           <ButtonGroup>
@@ -22,8 +23,10 @@ class DemoDropdownSection extends React.Component {
             <DropdownTrigger dropdown={<DemoUtilityDropdown/>}>
               <Button>Utility Dropdown</Button>
             </DropdownTrigger>
-            <DropdownTrigger dropdown={<DemoActionMenu/>}>
-              <Button canonStyle='action'>Actions</Button>
+            <DropdownTrigger dropdown={<DemoActionMenu/>} alignment='right'>
+              <div style={ {float: 'right'} }>
+                <Button canonStyle='action'>Actions</Button>
+              </div>
             </DropdownTrigger>
             <DropdownTrigger dropdown={<DemoActionMenu/>}>
               <div className="rs-cog rs-dropdown-toggle"></div>

--- a/src/Dropdown.jsx
+++ b/src/Dropdown.jsx
@@ -9,9 +9,13 @@ const DROPDOWN_TYPES = {
 
 class Dropdown extends React.Component {
   render() {
-    let style, classes;
+    let dropdownStyle, menuStyle, classes;
 
-    style = { float: 'left' };
+    dropdownStyle = { float: 'left' };
+
+    if (this.props.alignment) {
+      menuStyle = { position: 'static' };
+    }
 
     classes = classNames(
       this.props.className,
@@ -19,8 +23,8 @@ class Dropdown extends React.Component {
     );
 
     return (
-      <div className={classes} style={style}>
-        <ul className='rs-dropdown-menu visible'>
+      <div className={classes} style={dropdownStyle}>
+        <ul className='rs-dropdown-menu visible' style={menuStyle}>
           { this._children() }
         </ul>
       </div>
@@ -35,11 +39,13 @@ class Dropdown extends React.Component {
 }
 
 Dropdown.defaultProps = {
-  type: 'action'
+  type: 'action',
+  alignment: 'left'
 };
 
 Dropdown.propTypes = {
   type: React.PropTypes.oneOf(['primary', 'utility', 'action']),
+  alignment: React.PropTypes.oneOf['left', 'right'],
   hideCallback: React.PropTypes.func.isRequired
 };
 

--- a/src/DropdownTrigger.jsx
+++ b/src/DropdownTrigger.jsx
@@ -74,6 +74,7 @@ class DropdownTrigger extends React.Component {
     this._renderDropdown();
     this._listenToRootCloseEvents();
     this.setState({ isDropdownDisplayed: true });
+    this._tether.position();
   }
 
   _renderDropdown() {
@@ -82,7 +83,8 @@ class DropdownTrigger extends React.Component {
     dropdown = React.cloneElement(
       this.props.dropdown,
       {
-        hideCallback: this._hide.bind(this)
+        hideCallback: this._hide.bind(this),
+        tether: this.props.alignment
       }
     );
 
@@ -99,8 +101,8 @@ class DropdownTrigger extends React.Component {
     let tetherConfig;
 
     tetherConfig = {
-      attachment: 'top left',
-      targetAttachment: 'bottom left'
+      attachment: `top ${this.props.alignment}`,
+      targetAttachment: `bottom ${this.props.alignment}`
     };
 
     tetherConfig.element = ReactDOM.findDOMNode(this._containerDiv);
@@ -137,7 +139,12 @@ class DropdownTrigger extends React.Component {
 }
 
 DropdownTrigger.propTypes = {
-  dropdown: React.PropTypes.element
+  dropdown: React.PropTypes.element,
+  alignment: React.PropTypes.oneOf['left', 'right']
+};
+
+DropdownTrigger.defaultProps = {
+  alignment: 'left'
 };
 
 export default DropdownTrigger;

--- a/test/DropdownSpec.jsx
+++ b/test/DropdownSpec.jsx
@@ -31,12 +31,25 @@ describe('Dropdown', () => {
     expect(dropdown.props.type).toBe('action');
   });
 
-  it('renders children', () => {
+  describe('dropdown menu', () => {
     let menu;
 
-    menu = TestUtils.findRenderedDOMComponentWithClass(dropdown, 'rs-dropdown-menu');
+    beforeEach(() => {
+      menu = TestUtils.findRenderedDOMComponentWithClass(dropdown, 'rs-dropdown-menu');
+    });
 
-    expect(ReactDOM.findDOMNode(menu).textContent).toBe('Dropdown Item...');
+    it('overrides positioning to static positioning if alignment is passed in as prop', () => {
+      dropdown = TestUtils.renderIntoDocument(
+        <Dropdown className='test-dropdown-class' alignment='right' hideCallback={hideFunction}><DropdownItem type='link'>Dropdown Item...</DropdownItem></Dropdown>
+      );
+      menu = TestUtils.findRenderedDOMComponentWithClass(dropdown, 'rs-dropdown-menu');
+
+      expect(ReactDOM.findDOMNode(menu).style.position).toBe('static');
+    });
+
+    it('renders children', () => {
+      expect(ReactDOM.findDOMNode(menu).textContent).toBe('Dropdown Item...');
+    });
   });
 
   it('passes hide callback down to dropdown items', () => {

--- a/test/DropdownTriggerSpec.jsx
+++ b/test/DropdownTriggerSpec.jsx
@@ -12,14 +12,14 @@ describe('DropdownTrigger', () => {
 
   const hideFunction = () => { };
 
-  const renderDropdown = () => {
+  const renderDropdown = (menuAlignment) => {
     dropdownTrigger = TestUtils.renderIntoDocument(
-      <DropdownTrigger dropdown={<Dropdown hideCallback={hideFunction}><DropdownItem id='test-dropdown-item'>Hello</DropdownItem></Dropdown>}>
+      <DropdownTrigger alignment={menuAlignment} dropdown={<Dropdown hideCallback={hideFunction}><DropdownItem id='test-dropdown-item'>Hello</DropdownItem></Dropdown>}>
         <Button>Hello</Button>
       </DropdownTrigger>
     );
 
-    tether = jasmine.createSpyObj('tether', ['destroy']);
+    tether = jasmine.createSpyObj('tether', ['destroy', 'position']);
     spyOn(dropdownTrigger, '_createTether').and.returnValue(tether);
   };
 
@@ -60,7 +60,7 @@ describe('DropdownTrigger', () => {
         expect(dropdownTrigger._dropdownNode).not.toBeNull();
       });
 
-      it('renders the dropdown to the bottom of the trigger', () => {
+      it('renders the dropdown to the bottom of the trigger, tethering on the left by default', () => {
         renderDropdown();
         clickTrigger();
 
@@ -70,6 +70,32 @@ describe('DropdownTrigger', () => {
           attachment: 'top left',
           targetAttachment: 'bottom left'
         });
+      });
+
+      it("tethers the dropdown on the right when value 'right' is passed in as alignment prop", () => {
+        renderDropdown('right');
+        clickTrigger();
+
+        expect(dropdownTrigger._createTether).toHaveBeenCalledWith({
+          element: ReactDOM.findDOMNode(dropdownTrigger._containerDiv),
+          target: ReactDOM.findDOMNode(dropdownTrigger),
+          attachment: 'top right',
+          targetAttachment: 'bottom right'
+        });
+      });
+
+      it('calls position on the tether', () => {
+        renderDropdown();
+        clickTrigger();
+
+        expect(tether.position).toHaveBeenCalled();
+      });
+
+      it('passes the alignment prop to the dropdown', () => {
+        renderDropdown();
+        clickTrigger();
+
+        expect(dropdownTrigger.props.dropdown.props.alignment).toBe('left');
       });
 
       it('hides the dropdown when the trigger is clicked again', () => {
@@ -85,7 +111,7 @@ describe('DropdownTrigger', () => {
       it('hides the dropdown when pressing escape', () => {
         let keyUpEvent;
 
-        renderDropdown('right');
+        renderDropdown();
         clickTrigger();
 
         keyUpEvent = document.createEvent('CustomEvent');
@@ -98,7 +124,7 @@ describe('DropdownTrigger', () => {
       });
 
       it('hides the dropdown when clicking outside of the dropdown', () => {
-        renderDropdown('right');
+        renderDropdown();
         clickTrigger();
 
         TestUtils.Simulate.click(ReactDOM.findDOMNode(dropdownTrigger));


### PR DESCRIPTION
Introduces prop tether with value of 'right' or 'left' (default 'left') to DropdownTrigger.
Value of 'right' will tether the dropdown menu to the right of the trigger.