### PR TITLE
feat(popover): Override tether config

### DIFF
--- a/src/Popover.jsx
+++ b/src/Popover.jsx
@@ -149,8 +149,8 @@ class Popover extends React.Component {
         };
     }
 
-    if (this.props.offset) {
-      tetherConfig.offset = this.props.offset;
+    if (this.props.tetherConfig) {
+      tetherConfig = Object.assign(tetherConfig, this.props.tetherConfig);
     }
     tetherConfig.element = ReactDOM.findDOMNode(this._containerDiv);
     tetherConfig.target = this._getTarget();
@@ -189,13 +189,13 @@ Popover.propTypes = {
   children: React.PropTypes.element.isRequired,
   isModal: React.PropTypes.bool,
   isOpen: React.PropTypes.bool,
-  offset: React.PropTypes.string,
   onRequestClose: React.PropTypes.func.isRequired,
   placement: React.PropTypes.oneOf(['right', 'bottom-right', 'left', 'bottom-left', 'center']),
   target: React.PropTypes.oneOfType([
     React.PropTypes.string,
     React.PropTypes.func
-  ]).isRequired
+  ]).isRequired,
+  tetherConfig: React.PropTypes.object
 };
 
 export default Popover;

--- a/test/PopoverSpec.jsx
+++ b/test/PopoverSpec.jsx
@@ -7,7 +7,7 @@ import TestUtils from 'react-addons-test-utils';
 describe('Popover', () => {
   let popover, tether, requestCloseCallback, closeCallBackCalled;
 
-  const renderPopover = (placement, isOpen, useTargetCallback, offset, isModal) => {
+  const renderPopover = (placement, isOpen, useTargetCallback, tetherConfig, isModal) => {
     let target;
 
     requestCloseCallback = (e) => {
@@ -27,7 +27,7 @@ describe('Popover', () => {
         isOpen={isOpen}
         onRequestClose={requestCloseCallback}
         target={target}
-        offset={offset}
+        tetherConfig={tetherConfig}
         isModal={isModal}>
         <PopoverOverlay>
           This is the popover content
@@ -142,14 +142,19 @@ describe('Popover', () => {
       });
     });
 
-    it('can override the offsets', () => {
-      renderPopover('bottom-left', true, false, '10px 10px');
+    it('can override tether properties', () => {
+      renderPopover(
+        'bottom-left',
+        true,
+        false,
+        { offset: '10px 10px', attachment: 'left', targetAttachment: 'right'}
+      );
 
       expect(Popover.prototype._createTether).toHaveBeenCalledWith({
         element: ReactDOM.findDOMNode(popover._containerDiv),
         target: ReactDOM.findDOMNode(document.getElementById('some-element-id')),
-        attachment: 'top right',
-        targetAttachment: 'bottom left',
+        attachment: 'left',
+        targetAttachment: 'right',
         offset: '10px 10px'
       });
     });


### PR DESCRIPTION
Allow users to manually override all tether config options. This allows users to have better control over placement of popovers for special cases.

Resolves issue #77