### PR TITLE
Fix(Popover) don't add rs-popover class if it already exists

### DIFF
--- a/src/Popover.jsx
+++ b/src/Popover.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import Tether from 'tether';
 import PopoverBackground from './PopoverBackground';
+import classNames from 'classnames';
 
 class Popover extends React.Component {
 
@@ -79,7 +80,9 @@ class Popover extends React.Component {
 
     this._backgroundDiv.style.display = 'block';
     ReactDOM.render(<PopoverBackground isModal={ this.props.isModal } onRequestClose={this.props.onRequestClose} />, this._backgroundDiv);
-    this._containerDiv.className += ' rs-popover';
+
+    let containerClasses = this._containerDiv.className.split(' ');
+    this._containerDiv.className = classNames(containerClasses, {'rs-popover': containerClasses.indexOf('rs-popover') < 0});
 
     if (!this._tether) {
       this._tether = this._createTether(this._getTetherConfig());

--- a/test/PopoverSpec.jsx
+++ b/test/PopoverSpec.jsx
@@ -10,14 +10,10 @@ describe('Popover', () => {
   const renderPopover = (placement, isOpen, useTargetCallback, offset, isModal) => {
     let target;
 
-    setFixtures('<div id="content"><div id="some-element-id">The Target</div><div id="container"></div></div>');
-
     requestCloseCallback = (e) => {
       closeCallBackCalled = true;
       return e;
     };
-    tether = jasmine.createSpyObj('tether', ['destroy', 'position']);
-    spyOn(Popover.prototype, '_createTether').and.returnValue(tether);
 
     if (useTargetCallback) {
       target = () => document.getElementById('some-element-id');
@@ -42,6 +38,9 @@ describe('Popover', () => {
   };
 
   beforeEach(() => {
+    setFixtures('<div id="content"><div id="some-element-id">The Target</div><div id="container"></div></div>');
+    tether = jasmine.createSpyObj('tether', ['destroy', 'position']);
+    spyOn(Popover.prototype, '_createTether').and.returnValue(tether);
     closeCallBackCalled = false;
   });
 
@@ -60,6 +59,14 @@ describe('Popover', () => {
     renderPopover('right', true);
 
     expect(tether.position).toHaveBeenCalled();
+  });
+
+  it('adds the rs-popover class once', () => {
+    renderPopover('right', true);
+    renderPopover('left', true);
+
+    let container = ReactDOM.findDOMNode(popover._containerDiv);
+    expect(container.className.trim()).toBe('rs-popover');
   });
 
   it('renders the popover overlay', () => {


### PR DESCRIPTION
Noticed the container was getting an extra 'rs-popover' class every time its props updated.  Adding a check for the class so it won't be added if it already exists.