### PR TITLE
chore(release): v 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### Version 0.11.0
+1. New `tether` prop for the `Popover` component.
+  a. This prop allows a user to override all tether config options.
+  b. BREAKING CHANGE: `offset` prop has been removed from `Popover`, and can now be set in the `tether` config prop
+2. Fix to not add the `rs-popover` class if it already exists when rendering a popover.
+
 ### Version 0.10.1
 1. Fix the propType of the `alignment` property on the dropdown and dropdown trigger components.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "canon-react",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "Rackspace Canon components built with React",
   "repository": {
     "type": "git",


### PR DESCRIPTION
1. New 'tether' prop for the 'Popover' component.
1.a. This prop allows a user to override all tether config options.
1.b. BREAKING CHANGE: 'offset' prop has been removed from 'Popover', and can now be set in the 'tether' config prop
2. Fix to not add the 'rs-popover' class if it already exists when rendering a popover