### PR TITLE
chore(release): v 0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Version 0.11.1
+1. Render `Popover` subtree component into a container so it will receive the context from its parent.
+
 ### Version 0.11.0
 1. New `tether` prop for the `Popover` component.
   a. This prop allows a user to override all tether config options.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "canon-react",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Rackspace Canon components built with React",
   "repository": {
     "type": "git",


### PR DESCRIPTION
1. Render 'Popover' subtree component into a container so it will receive the context from its parent.