### PR TITLE
feat(details components): add multiple new details components

### DIFF
--- a/demo/DemoDetailSection.jsx
+++ b/demo/DemoDetailSection.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+import Button from './Button';
+import ButtonGroup from './ButtonGroup';
+import DetailList from './DetailList';
+import DetailItem from './DetailItem';
+import DetailItemKey from './DetailItemKey';
+import DetailItemValue from './DetailItemValue';
+
+class DemoDetailSection extends React.Component {
+  render() {
+    return (
+      <div className='rs-detail-section'>
+        <div className='rs-detail-section-header'>
+          <h2>Details</h2>
+        </div>
+        <div className='rs-detail-section-body'>
+          <table>
+            <thead>
+              <tr>
+                <td>Component</td>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
+                  <DetailList>
+                    <DetailItem>
+                      <DetailItemKey>Server ID</DetailItemKey>
+                      <DetailItemValue>adfsad-lkjasdli-aldjsdk-alkasdlkf</DetailItemValue>
+                    </DetailItem>
+                    <DetailItem>
+                      <DetailItemKey>Region</DetailItemKey>
+                      <DetailItemValue>Dallas (DFW)</DetailItemValue>
+                    </DetailItem>
+                  </DetailList>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default DemoDetailSection;

--- a/demo/DemoView.jsx
+++ b/demo/DemoView.jsx
@@ -8,6 +8,7 @@ import DemoStatusIndicatorSection from './DemoStatusIndicatorSection';
 import DemoTooltipSection from './DemoTooltipSection';
 import DemoDropdownSection from './DemoDropdownSection';
 import DemoFacetsSection from './DemoFacetsSection';
+import DemoDetailSection from './DemoDetailSection';
 
 class DemoView extends React.Component {
   render() {
@@ -15,6 +16,7 @@ class DemoView extends React.Component {
       <div>
         <DemoButtonSection />
         <DemoButtonGroupSection />
+        <DemoDetailSection />
         <DemoProgressBarSection />
         <DemoStatusIndicatorSection />
         <DemoPopoverSection />

--- a/src/DetailItem.jsx
+++ b/src/DetailItem.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import classnames from 'classnames';
+
+class DetailItem extends React.Component {
+  render() {
+    return (
+      <li {...this.props} className={ classnames('rs-detail-item', this.props.className) }>
+        {this.props.children}
+      </li>
+    );
+  }
+}
+
+DetailItem.propTypes = {
+  children: React.PropTypes.node.isRequired,
+  className: React.PropTypes.string
+};
+
+export default DetailItem;

--- a/src/DetailItemKey.jsx
+++ b/src/DetailItemKey.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import classnames from 'classnames';
+
+class DetailItemKey extends React.Component {
+  render() {
+    return (
+      <div {...this.props} className={ classnames('rs-detail-key', this.props.className) }>
+        {this.props.children}
+      </div>
+    );
+  }
+}
+
+DetailItemKey.propTypes = {
+  children: React.PropTypes.node.isRequired,
+  className: React.PropTypes.string
+};
+
+export default DetailItemKey;

--- a/src/DetailItemValue.jsx
+++ b/src/DetailItemValue.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import classnames from 'classnames';
+
+class DetailItemValue extends React.Component {
+  render() {
+    return (
+      <div {...this.props} className={ classnames('rs-detail-value', this.props.className) }>
+        {this.props.children}
+      </div>
+    );
+  }
+}
+
+DetailItemValue.propTypes = {
+  children: React.PropTypes.node.isRequired,
+  className: React.PropTypes.string
+};
+
+export default DetailItemValue;

--- a/src/DetailList.jsx
+++ b/src/DetailList.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import classnames from 'classnames';
+
+class DetailList extends React.Component {
+  render() {
+    return (
+      <ul {...this.props} className={classnames('rs-detail-list', this.props.className) }>
+        {this.props.children}
+      </ul>
+    );
+  }
+}
+
+DetailList.propTypes = {
+  children: React.PropTypes.node.isRequired,
+  className: React.PropTypes.string
+};
+
+export default DetailList;

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,10 @@ import Button from './Button';
 import ButtonGroup from './ButtonGroup';
 import Criteria from './Criteria';
 import Divider from './Divider';
+import DetailItem from './DetailItem';
+import DetailItemKey from './DetailItemKey';
+import DetailItemValue from './DetailItemValue';
+import DetailList from './DetailList';
 import Dropdown from './Dropdown';
 import DropdownItem from './DropdownItem';
 import DropdownTrigger from './DropdownTrigger';
@@ -20,6 +24,10 @@ export {
   Button,
   ButtonGroup,
   Criteria,
+  DetailItem,
+  DetailItemKey,
+  DetailItemValue,
+  DetailList,
   Divider,
   Dropdown,
   DropdownItem,

--- a/test/DetailItemKeySpec.jsx
+++ b/test/DetailItemKeySpec.jsx
@@ -1,0 +1,52 @@
+import DetailItemKey from '../transpiled/DetailItemKey';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import TestUtils from 'react-addons-test-utils';
+
+describe('DetailItemKey', () => {
+  let detailItemKey;
+
+  afterEach(() => {
+    ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(detailItemKey).parentNode);
+  });
+
+  it('renders provided class name correctly', () => {
+    detailItemKey = TestUtils.renderIntoDocument(
+      <DetailItemKey id='detail-item-key-id' className='test-detail-item-key-class'>
+        Test Detail Item
+      </DetailItemKey>
+    );
+
+    expect(ReactDOM.findDOMNode(detailItemKey)).toHaveClass('rs-detail-key test-detail-item-key-class');
+  });
+
+  it('has only default classs when custom class not provided', () => {
+    detailItemKey = TestUtils.renderIntoDocument(
+      <DetailItemKey id='rs-detail-key'>
+        Test Detail Item Key
+      </DetailItemKey>
+    );
+
+    expect(ReactDOM.findDOMNode(detailItemKey)).toHaveClass('rs-detail-key');
+  });
+
+  it('has correct id when passed in as prop', () => {
+    detailItemKey = TestUtils.renderIntoDocument(
+      <DetailItemKey id='detail-item-key-id' className='test-detail-item-key-class'>
+        Test Detail Item
+      </DetailItemKey>
+    );
+
+    expect(ReactDOM.findDOMNode(detailItemKey).id).toBe('detail-item-key-id');
+  });
+
+  it('renders passed in children', () => {
+    detailItemKey = TestUtils.renderIntoDocument(
+      <DetailItemKey id='detail-item-id' className='test-detail-item-key-class'>
+        <div id='target-child'>Target Child</div>
+      </DetailItemKey>
+    );
+
+    expect(TestUtils.findRenderedDOMComponentWithClass(detailItemKey, 'test-detail-item-key-class')).not.toBeNull();
+  });
+});

--- a/test/DetailItemSpec.jsx
+++ b/test/DetailItemSpec.jsx
@@ -1,0 +1,52 @@
+import DetailItem from '../transpiled/DetailItem';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import TestUtils from 'react-addons-test-utils';
+
+describe('DetailItem', () => {
+  let detailItem;
+
+  afterEach(() => {
+    ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(detailItem).parentNode);
+  });
+
+  it('renders provided class name correctly', () => {
+    detailItem = TestUtils.renderIntoDocument(
+      <DetailItem id='detail-item-id' className='test-detail-item-class'>
+        Test Detail Item
+      </DetailItem>
+    );
+
+    expect(ReactDOM.findDOMNode(detailItem)).toHaveClass('rs-detail-item test-detail-item-class');
+  });
+
+  it('has only default classs when custom class not provided', () => {
+    detailItem = TestUtils.renderIntoDocument(
+      <DetailItem id='detail-item-id'>
+        Test Detail Item
+      </DetailItem>
+    );
+
+    expect(ReactDOM.findDOMNode(detailItem)).toHaveClass('rs-detail-item');
+  });
+
+  it('has correct id when passed in as prop', () => {
+    detailItem = TestUtils.renderIntoDocument(
+      <DetailItem id='detail-item-id' className='test-detail-item-class'>
+        Test Detail Item
+      </DetailItem>
+    );
+
+    expect(ReactDOM.findDOMNode(detailItem).id).toBe('detail-item-id');
+  });
+
+  it('renders passed in children', () => {
+    detailItem = TestUtils.renderIntoDocument(
+      <DetailItem id='detail-item-id' className='test-detail-item-class'>
+        <div id='target-child'>Target Child</div>
+      </DetailItem>
+    );
+
+    expect(TestUtils.findRenderedDOMComponentWithClass(detailItem, 'test-detail-item-class')).not.toBeNull();
+  });
+});

--- a/test/DetailItemValueSpec.jsx
+++ b/test/DetailItemValueSpec.jsx
@@ -1,0 +1,52 @@
+import DetailItemValue from '../transpiled/DetailItemValue';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import TestUtils from 'react-addons-test-utils';
+
+describe('DetailItemValue', () => {
+  let detailItemValue;
+
+  afterEach(() => {
+    ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(detailItemValue).parentNode);
+  });
+
+  it('renders provided class name correctly', () => {
+    detailItemValue = TestUtils.renderIntoDocument(
+      <DetailItemValue id='detail-item-value-id' className='test-detail-item-value-class'>
+        Test Detail Item
+      </DetailItemValue>
+    );
+
+    expect(ReactDOM.findDOMNode(detailItemValue)).toHaveClass('rs-detail-value test-detail-item-value-class');
+  });
+
+  it('has only default class when custom class not provided', () => {
+    detailItemValue = TestUtils.renderIntoDocument(
+      <DetailItemValue id='rs-detail-value'>
+        Test Detail Item Value
+      </DetailItemValue>
+    );
+
+    expect(ReactDOM.findDOMNode(detailItemValue)).toHaveClass('rs-detail-value');
+  });
+
+  it('has correct id when passed in as prop', () => {
+    detailItemValue = TestUtils.renderIntoDocument(
+      <DetailItemValue id='detail-item-value-id' className='test-detail-item-value-class'>
+        Test Detail Item
+      </DetailItemValue>
+    );
+
+    expect(ReactDOM.findDOMNode(detailItemValue).id).toBe('detail-item-value-id');
+  });
+
+  it('renders passed in children', () => {
+    detailItemValue = TestUtils.renderIntoDocument(
+      <DetailItemValue id='detail-item-id' className='test-detail-item-value-class'>
+        <div id='target-child'>Target Child</div>
+      </DetailItemValue>
+    );
+
+    expect(TestUtils.findRenderedDOMComponentWithClass(detailItemValue, 'test-detail-item-value-class')).not.toBeNull();
+  });
+});

--- a/test/DetailListSpec.jsx
+++ b/test/DetailListSpec.jsx
@@ -1,0 +1,52 @@
+import DetailList from '../transpiled/DetailList';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import TestUtils from 'react-addons-test-utils';
+
+describe('DetailList', () => {
+  let detailList;
+
+  afterEach(() => {
+    ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(detailList).parentNode);
+  });
+
+  it('renders provided class name correctly', () => {
+    detailList = TestUtils.renderIntoDocument(
+      <DetailList id='detail-list-id' className='test-detail-list-class'>
+        Test Detail List
+      </DetailList>
+    );
+
+    expect(ReactDOM.findDOMNode(detailList)).toHaveClass('rs-detail-list test-detail-list-class');
+  });
+
+  it('has only default classs when custom class not provided', () => {
+    detailList = TestUtils.renderIntoDocument(
+      <DetailList id='detail-list-id'>
+        Test Detail List
+      </DetailList>
+    );
+
+    expect(ReactDOM.findDOMNode(detailList)).toHaveClass('rs-detail-list');
+  });
+
+  it('has correct id when passed in as prop', () => {
+    detailList = TestUtils.renderIntoDocument(
+      <DetailList id='detail-list-id' className='test-detail-list-class'>
+        Test Detail List
+      </DetailList>
+    );
+
+    expect(ReactDOM.findDOMNode(detailList).id).toBe('detail-list-id');
+  });
+
+  it('renders passed in children', () => {
+    detailList = TestUtils.renderIntoDocument(
+      <DetailList id='detail-list-id' className='test-detail-list-class'>
+        <div id='target-child'>Target Child</div>
+      </DetailList>
+    );
+
+    expect(TestUtils.findRenderedDOMComponentWithClass(detailList, 'test-detail-list-class')).not.toBeNull();
+  });
+});


### PR DESCRIPTION
Added DetailList, DetailItem, DetailItemValue, DetailItemKey components
and their respective tests/demo. Will allow the use of these canon-react
components elsewhere.