### PR TITLE
feat: added form and field components

### DIFF
--- a/demo/DemoForm.jsx
+++ b/demo/DemoForm.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+import Form from './Form';
+import FormField from './FormField';
+import DetailsSection from './DetailsSection';
+
+class DemoForm extends React.Component {
+  render() {
+    return (
+      <DetailsSection title="Form">
+        <Form size="large">
+          <FormField  label="Standard Input" help="This is a field with no particular status">
+            <input type="text" />
+          </FormField>
+          <FormField error="This input is not valid" label="Error Field">
+            <input type="text" value="invalid text" />
+          </FormField>
+          <FormField success="This input is valid" label={ <span><i>Fixed</i> Error Field</span>}>
+            <select>
+               <option>Option One</option>
+               <option>Option Two</option>
+             </select>
+          </FormField>
+        </Form>
+      </DetailsSection>
+    );
+  }
+}
+
+export default DemoForm;

--- a/demo/DemoFormPopover.jsx
+++ b/demo/DemoFormPopover.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import FormField from './FormField';
+import FormPopover from './FormPopover';
+
+class DemoPopover extends React.Component {
+  render() {
+    return (
+      <FormPopover {...this.props} >
+        <FormField label="Field">
+          <input type="text" />
+        </FormField>
+      </FormPopover>
+    );
+  }
+}
+
+export default DemoPopover;

--- a/demo/DemoPopover.jsx
+++ b/demo/DemoPopover.jsx
@@ -1,35 +1,20 @@
 import React from 'react';
 
 import Button from './Button';
-import Popover from './Popover';
-import PopoverOverlay from './PopoverOverlay';
-import PopoverBody from './PopoverBody';
-import PopoverFooter from './PopoverFooter';
-import ProcessingIndicator from './ProcessingIndicator';
+import FormPopover from './FormPopover';
+import FormField from './FormField';
 
 class DemoPopover extends React.Component {
-
   render() {
     return (
-      <Popover placement={this.props.placement} isOpen={this.props.isOpen} onRequestClose={this.props.onRequestClose} target={this.props.target} isModal={ this.props.isModal }>
-        <PopoverOverlay>
-          <PopoverBody>
-            <form className='rs-form-horizontal rs-form-medium'>
-              <div className='rs-control-group'>
-                <label className='rs-control-label'>Field 1</label>
-                <div className='rs-controls'>
-                  <input autoFocus type='text'/>
-                </div>
-              </div>
-            </form>
-          </PopoverBody>
-          <PopoverFooter>
-            <Button canonStyle='primary' onClick={this.props.onRequestClose}>Save</Button>
-            <Button canonStyle='link' onClick={this.props.onRequestClose}>Cancel</Button>
-            <ProcessingIndicator hidden={true} />
-          </PopoverFooter>
-        </PopoverOverlay>
-      </Popover>
+      <FormPopover
+        {...this.props}
+        submitButton={<Button canonStyle="primary">Save</Button>}
+        size="medium" >
+        <FormField label="Field 1">
+          <input type="text" />
+        </FormField>
+      </FormPopover>
     );
   }
 }

--- a/demo/DemoPopoverSection.jsx
+++ b/demo/DemoPopoverSection.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 import Button from './Button';
+import DemoFormPopover from './DemoFormPopover';
 import DemoPopover from './DemoPopover';
 
 class DemoPopoverSection extends React.Component {
@@ -14,7 +15,9 @@ class DemoPopoverSection extends React.Component {
       bottomRightPopoverOpen: false,
       bottomLeftPopoverOpen: false,
       bottomRightFunctionPopoverOpen: false,
-      bottomLeftModalPopoverOpen: false
+      bottomLeftModalPopoverOpen: false,
+      formPopoverOpen: false,
+      formPopoverSubmitting: false
     };
   }
 
@@ -80,6 +83,18 @@ class DemoPopoverSection extends React.Component {
                     isOpen={ this.state.bottomLeftModalPopoverOpen }
                     isModal={ true }
                     onRequestClose={ () => { this.setState({bottomLeftModalPopoverOpen: false}) } }/>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <Button id="form-popover-button-id" onClick={() => { this.setState({formPopoverOpen: true, formPopoverSubmitting: false}) } }>Submittable</Button>
+                  <DemoFormPopover
+                    placement="right"
+                    processing={this.state.formPopoverSubmitting}
+                    target={ () => document.getElementById('form-popover-button-id') }
+                    isOpen={ this.state.formPopoverOpen }
+                    onSubmit={ () => { this.setState({formPopoverSubmitting: true}) } }
+                    onRequestClose={ () => { this.setState({formPopoverOpen: false}) } } />
                 </td>
               </tr>
             </tbody>

--- a/demo/DemoView.jsx
+++ b/demo/DemoView.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import DemoButtonSection from './DemoButtonSection';
 import DemoButtonGroupSection from './DemoButtonGroupSection';
+import DemoForm from './DemoForm';
 import DemoPopoverSection from './DemoPopoverSection';
 import DemoProgressBarSection from './DemoProgressBarSection';
 import DemoStatusIndicatorSection from './DemoStatusIndicatorSection';
@@ -17,6 +18,7 @@ class DemoView extends React.Component {
         <DemoButtonSection />
         <DemoButtonGroupSection />
         <DemoDetailSection />
+        <DemoForm />
         <DemoProgressBarSection />
         <DemoStatusIndicatorSection />
         <DemoPopoverSection />

--- a/src/DetailsSection.jsx
+++ b/src/DetailsSection.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export default class DetailsSection extends React.Component {
+  render() {
+    return (
+      <div className="rs-detail-section">
+        <div className="rs-detail-section-header">
+          <div className="rs-detail-section-title">{this.props.title}</div>
+        </div>
+        <div className="rs-detail-section-body">
+          {this.props.children}
+        </div>
+      </div>
+    );
+  }
+}
+
+DetailsSection.propTypes = {
+  title: React.PropTypes.node.isRequired,
+  children: React.PropTypes.node
+};

--- a/src/Form.jsx
+++ b/src/Form.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import classNames from 'classnames';
+
+const SIZE_CLASSES = {
+  'xsmall': 'rs-form-xsmall',
+  'small': 'rs-form-small',
+  'medium': 'rs-form-medium',
+  'large': 'rs-form-large',
+  'xlarge': 'rs-form-xlarge'
+};
+
+export default class Form extends React.Component {
+  render() {
+    let classes, sizeClass;
+
+    sizeClass = SIZE_CLASSES[this.props.size];
+    classes = classNames(
+      'rs-form-horizontal',
+      sizeClass,
+      this.props.create ? 'rs-form-create' : undefined,
+      this.props.className
+    );
+
+    return (
+      <form {...this.props} className={classes}>
+        {this.props.children}
+      </form>
+    );
+  }
+}
+
+Form.propTypes = {
+  create: React.PropTypes.boolean,
+  className: React.PropTypes.string,
+  size: React.PropTypes.oneOf(Object.keys(SIZE_CLASSES)),
+  children: React.PropTypes.node.isRequired
+};

--- a/src/FormField.jsx
+++ b/src/FormField.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import FormFieldHelp from './FormFieldHelp';
+import FormFieldValidationBlock from './FormFieldValidationBlock';
+import classnames from 'classnames';
+
+export default class FormField extends React.Component {
+  render() {
+    return (
+      <div className={classnames('rs-control-group', { 'error': this.props.error, 'success': this.props.success })}>
+        <label className="rs-control-label">{this.props.label}</label>
+        <div className="rs-controls">
+          {this.props.children}
+          <FormFieldHelp help={this.props.help} />
+          <FormFieldValidationBlock value={this.props.error || this.props.success} />
+        </div>
+      </div>
+    );
+  }
+}
+
+FormField.propTypes = {
+  error: React.PropTypes.string,
+  success: React.PropTypes.string,
+  help: React.PropTypes.node,
+  label: React.PropTypes.node.isRequired,
+  children: React.PropTypes.node.isRequired
+};

--- a/src/FormFieldHelp.jsx
+++ b/src/FormFieldHelp.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default class FormFieldHelp extends React.Component {
+  render() {
+    return this.props.help ? (
+      <span className="rs-help-block">{this.props.help}</span>
+    ) : null;
+  }
+}
+
+FormFieldHelp.propTypes = {
+  help: React.PropTypes.node
+};

--- a/src/FormFieldValidationBlock.jsx
+++ b/src/FormFieldValidationBlock.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default class FormFieldValidationBlock extends React.Component {
+  render() {
+    return this.props.value ? (
+      <span className="rs-validation-block">
+        <i className="rs-validation-indicator"></i> {this.props.value}
+      </span>
+    ) : null;
+  }
+}
+
+FormFieldValidationBlock.propTypes = {
+  value: React.PropTypes.node
+};

--- a/src/FormPopover.jsx
+++ b/src/FormPopover.jsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import Button from './Button';
+import Form from './Form';
+import FormFieldValidationBlock from './FormFieldValidationBlock';
+import Popover from './Popover';
+import PopoverOverlay from './PopoverOverlay';
+import PopoverBody from './PopoverBody';
+import PopoverFooter from './PopoverFooter';
+import ProcessingIndicator from './ProcessingIndicator';
+
+class FormPopover extends React.Component {
+  render() {
+    let submitComponent, cancelComponent, popoverProps;
+
+    submitComponent = React.cloneElement(
+      this.props.submitButton,
+      { onClick: this._submit.bind(this), enabled: !this.props.processing }
+    );
+    cancelComponent = React.cloneElement(
+      this.props.cancelButton,
+      { onClick: this._cancel.bind(this), hidden: this.props.processing }
+    );
+
+    popoverProps = Object.assign({}, this.props);
+    delete popoverProps.children;
+
+    return (
+      <Popover {...this.props} >
+        <PopoverOverlay>
+          <Form onsubmit={this.props.onSubmit} size={this.props.formSize} >
+            <PopoverBody>
+              {this.props.children}
+            </PopoverBody>
+            <PopoverFooter>
+              {submitComponent}
+              {cancelComponent}
+              <ProcessingIndicator hidden={ !this.props.processing }/>
+              <FormFieldValidationBlock value={this.props.error} />
+            </PopoverFooter>
+          </Form>
+        </PopoverOverlay>
+      </Popover>
+    );
+  }
+
+  _cancel(event) {
+    if (event && event.preventDefault) {
+      event.preventDefault();
+    }
+    this.props.onRequestClose();
+  }
+
+  _submit(event) {
+    if (event && event.preventDefault) {
+      event.preventDefault();
+    }
+    this.props.onSubmit(event);
+  }
+}
+
+FormPopover.propTypes = {
+  // form
+  formSize: React.PropTypes.string,
+  error: React.PropTypes.node,
+  processing: React.PropTypes.bool.isRequired,
+  onSubmit: React.PropTypes.func.isRequired,
+  // popover layout
+  cancelButton: React.PropTypes.element.isRequired,
+  submitButton: React.PropTypes.element.isRequired,
+  // popover content
+  children: React.PropTypes.node.isRequired,
+  // popover
+  isOpen: React.PropTypes.bool.isRequired,
+  target: React.PropTypes.string.isRequired,
+  placement: React.PropTypes.string.isRequired,
+  onRequestClose: React.PropTypes.func.isRequired
+};
+
+FormPopover.defaultProps = {
+  error: null,
+  cancelButton: <Button canonStyle="link">Cancel</Button>,
+  submitButton: <Button canonStyle="primary">Submit</Button>,
+  processing: false,
+  isOpen: true,
+  placement: 'right'
+};
+
+export default FormPopover;

--- a/test/DetailsSectionSpec.jsx
+++ b/test/DetailsSectionSpec.jsx
@@ -1,0 +1,30 @@
+import DetailsSection from '../transpiled/DetailsSection';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import TestUtils from 'react-addons-test-utils';
+
+describe('DetailsSection', () => {
+  let detailsSection;
+
+  afterEach(() => {
+    ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(detailsSection).parentNode);
+  });
+
+  it('displays the title', () => {
+    let title;
+
+    detailsSection = TestUtils.renderIntoDocument(<DetailsSection title="test message" />);
+    title = TestUtils.findRenderedDOMComponentWithClass(detailsSection, 'rs-detail-section-title');
+    expect(title.getDOMNode().textContent).toBe('test message');
+  });
+
+  it('displays children', () => {
+    let sectionChild;
+
+    detailsSection = TestUtils.renderIntoDocument(
+      <DetailsSection><span className="test-child">test value</span></DetailsSection>
+    );
+    sectionChild = TestUtils.findRenderedDOMComponentWithClass(detailsSection, 'test-child');
+    expect(sectionChild.getDOMNode().textContent).toBe('test value');
+  });
+});

--- a/test/FormFieldHelpSpec.jsx
+++ b/test/FormFieldHelpSpec.jsx
@@ -1,0 +1,24 @@
+import FormFieldHelp from '../transpiled/FormFieldHelp';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import TestUtils from 'react-addons-test-utils';
+
+describe('FormFieldHelp', () => {
+  it('displays the help message', () => {
+    let message, formFieldHelp;
+
+    formFieldHelp = TestUtils.renderIntoDocument(<FormFieldHelp help="test message" />);
+    message = TestUtils.findRenderedDOMComponentWithClass(formFieldHelp, 'rs-help-block');
+    expect(message.getDOMNode().textContent).toBe('test message');
+
+    ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(formFieldHelp).parentNode);
+  });
+
+  it('returns null if no field is passed to it', () => {
+    let results, formFieldHelp;
+
+    formFieldHelp = TestUtils.renderIntoDocument(<FormFieldHelp />);
+    results = TestUtils.scryRenderedDOMComponentsWithClass(formFieldHelp, 'rs-help-block');
+    expect(results).toEqual([]);
+  });
+});

--- a/test/FormFieldSpec.jsx
+++ b/test/FormFieldSpec.jsx
@@ -1,0 +1,72 @@
+import FormField from '../transpiled/FormField';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import TestUtils from 'react-addons-test-utils';
+
+describe('FormField', () => {
+  let formField;
+
+  afterEach(() => {
+    ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(formField).parentNode);
+  });
+
+  describe('when there is an error', () => {
+    beforeEach(() => {
+      formField = TestUtils.renderIntoDocument(
+        <FormField error="Test error message">test</FormField>
+      );
+    });
+
+    it('adds the error class', () => {
+      let controlGroup;
+
+      controlGroup = TestUtils.findRenderedDOMComponentWithClass(formField, 'rs-control-group');
+      expect(controlGroup.getDOMNode()).toHaveClass('error');
+    });
+
+    it('adds the message to the validation block', () => {
+      let message;
+
+      message = TestUtils.findRenderedDOMComponentWithClass(formField, 'rs-validation-block');
+      expect(message.getDOMNode().textContent).toBe(' Test error message');
+    });
+  });
+
+  describe('when there is a fixed error', () => {
+    beforeEach(() => {
+      formField = TestUtils.renderIntoDocument(
+        <FormField success="Test success message">test</FormField>
+      );
+    });
+
+    it('adds the success class', () => {
+      let controlGroup;
+
+      controlGroup = TestUtils.findRenderedDOMComponentWithClass(formField, 'rs-control-group');
+      expect(controlGroup.getDOMNode()).toHaveClass('success');
+    });
+
+    it('adds the message to the validation block', () => {
+      let message;
+
+      message = TestUtils.findRenderedDOMComponentWithClass(formField, 'rs-validation-block');
+      expect(message.getDOMNode().textContent).toBe(' Test success message');
+    });
+  });
+
+  it('adds the help message', () => {
+    let message;
+
+    formField = TestUtils.renderIntoDocument(<FormField help="test help message">test</FormField>);
+    message = TestUtils.findRenderedDOMComponentWithClass(formField, 'rs-help-block');
+    expect(message.getDOMNode().textContent).toBe('test help message');
+  });
+
+  it('displays the label', () => {
+    let label;
+
+    formField = TestUtils.renderIntoDocument(<FormField label="test label">test</FormField>);
+    label = TestUtils.findRenderedDOMComponentWithClass(formField, 'rs-control-label');
+    expect(label.getDOMNode().textContent).toBe('test label');
+  });
+});

--- a/test/FormFieldValidationBlockSpec.jsx
+++ b/test/FormFieldValidationBlockSpec.jsx
@@ -1,0 +1,24 @@
+import FormFieldValidationBlock from '../transpiled/FormFieldValidationBlock';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import TestUtils from 'react-addons-test-utils';
+
+describe('FormFieldValidationBlock', () => {
+  it('displays the validation message', () => {
+    let message, formFieldValidationBlock;
+
+    formFieldValidationBlock = TestUtils.renderIntoDocument(<FormFieldValidationBlock value="test message" />);
+    message = TestUtils.findRenderedDOMComponentWithClass(formFieldValidationBlock, 'rs-validation-block');
+    expect(message.getDOMNode().textContent).toBe(' test message');
+
+    ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(formFieldValidationBlock).parentNode);
+  });
+
+  it('returns null if no field is passed to it', () => {
+    let results, formFieldValidationBlock;
+
+    formFieldValidationBlock = TestUtils.renderIntoDocument(<FormFieldValidationBlock />);
+    results = TestUtils.scryRenderedDOMComponentsWithClass(formFieldValidationBlock, 'rs-validation-block');
+    expect(results).toEqual([]);
+  });
+});

--- a/test/FormPopoverSpec.jsx
+++ b/test/FormPopoverSpec.jsx
@@ -1,0 +1,114 @@
+import Popover from '../transpiled/Popover';
+import FormPopover from '../transpiled/FormPopover';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import TestUtils from 'react-addons-test-utils';
+
+describe('FormPopover', () => {
+  let onCancel, onSubmit, tether;
+
+  beforeEach(() => {
+    setFixtures('<div id="content"><div id="container"></div><div id="popover-target></div></div>');
+    onCancel = jasmine.createSpy('onCancel');
+    onSubmit = jasmine.createSpy('onSubmit');
+
+    tether = jasmine.createSpyObj('tether', ['destroy', 'position']);
+    spyOn(Popover.prototype, '_createTether').and.returnValue(tether);
+  });
+
+  afterEach(() => {
+    ReactDOM.unmountComponentAtNode(document.getElementById('container'));
+    jasmine.getFixtures().cleanUp();
+  });
+
+  const renderPopover  = (popoverProps) => {
+    ReactDOM.render(
+      <FormPopover
+        onRequestClose={onCancel}
+        onSubmit={onSubmit}
+        target="popover-target"
+        isOpen={true}
+        {...popoverProps}>
+        test
+      </FormPopover>,
+      document.getElementById('container')
+    );
+  };
+
+  it('fires the submit callback on click', () => {
+    renderPopover({});
+    TestUtils.Simulate.click(document.querySelector('.rs-btn-primary'));
+
+    expect(onSubmit).toHaveBeenCalled();
+  });
+
+  it('prevents default behavior on submit', () => {
+    let eventCancelSpy;
+
+    eventCancelSpy = jasmine.createSpy('eventCancelSpy');
+    renderPopover({});
+    TestUtils.Simulate.click(
+      document.querySelector('.rs-btn-primary'),
+      { preventDefault: eventCancelSpy }
+    );
+
+    expect(eventCancelSpy).toHaveBeenCalled();
+  });
+
+  it('fires the request close callback on cancel', () => {
+    renderPopover({});
+    TestUtils.Simulate.click(document.querySelector('.rs-btn-link'));
+
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('prevents default behavior on cancel', () => {
+    let eventCancelSpy;
+
+    eventCancelSpy = jasmine.createSpy('eventCancelSpy');
+    renderPopover({});
+    TestUtils.Simulate.click(
+      document.querySelector('.rs-btn-link'),
+      { preventDefault: eventCancelSpy }
+    );
+
+    expect(eventCancelSpy).toHaveBeenCalled();
+  });
+
+  describe('while processing', () => {
+    beforeEach(() => {
+      renderPopover({ processing: true });
+    });
+
+    it('disables submit', () => {
+      expect(document.querySelector('.rs-btn-primary')).toHaveClass('disabled');
+    });
+
+    it('hides cancel', () => {
+      expect(document.querySelector('.rs-btn-link')).not.toBe(null);
+    });
+
+    it('shows the processing indicator', () => {
+      expect(document.querySelector('.rs-processing-indicator')).not.toHaveClass('rs-hidden');
+    });
+  });
+
+  it('enables submit', () => {
+    renderPopover({});
+    expect(document.querySelector('.rs-btn-primary')).not.toHaveClass('disabled');
+  });
+
+  it('shows cancel', () => {
+    renderPopover({});
+    expect(document.querySelector('.rs-btn-link')).not.toHaveClass('rs-hidden');
+  });
+
+  it('hides the processing indicator', () => {
+    expect(document.querySelector('.rs-processing-indicator')).toBe(null);
+  });
+
+  it('passes errors to the validation block', () => {
+    renderPopover({ error: 'this is a test error message'});
+    expect(document.querySelector('.rs-validation-block').textContent).toBe(' this is a test error message');
+  });
+});

--- a/test/FormSpec.jsx
+++ b/test/FormSpec.jsx
@@ -1,0 +1,38 @@
+import Form from '../transpiled/Form';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import TestUtils from 'react-addons-test-utils';
+
+describe('Form', () => {
+  let form;
+
+  afterEach(() => {
+    ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(form).parentNode);
+  });
+
+  it('adds the size class', () => {
+    form = TestUtils.renderIntoDocument(<Form size="xsmall">test</Form>);
+    expect(ReactDOM.findDOMNode(form)).toHaveClass('rs-form-xsmall');
+  });
+
+  it('does not add invalid size classes', () => {
+    form = TestUtils.renderIntoDocument(<Form size="ginormous">test</Form>);
+    expect(ReactDOM.findDOMNode(form)).not.toHaveClass('rs-form-ginormous');
+  });
+
+  it('adds the create class', () => {
+    form = TestUtils.renderIntoDocument(<Form create>test</Form>);
+    expect(ReactDOM.findDOMNode(form)).toHaveClass('rs-form-create');
+  });
+
+  it('does not add the create class if not present', () => {
+    form = TestUtils.renderIntoDocument(<Form>test</Form>);
+    expect(ReactDOM.findDOMNode(form)).not.toHaveClass('rs-form-create');
+  });
+
+  it('adds passed-in class names to the default ones', () => {
+    form = TestUtils.renderIntoDocument(<Form className="some-nonsense">test</Form>);
+    expect(ReactDOM.findDOMNode(form)).toHaveClass('some-nonsense');
+    expect(ReactDOM.findDOMNode(form)).toHaveClass('rs-form-horizontal');
+  });
+});


### PR DESCRIPTION
Added Form, FormField, and related components to encapsulate Canon forms and form validation messages

Changes are based on the Apollo changes here, updated to Canon-React patterns: https://github.com/racker/apollo/pull/45/files

I've removed FormButton and related, since they reproduce button logic we already have in other places.