### PR TITLE
Add list table

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -67,6 +67,7 @@ module.exports = function (grunt) {
           'test_bundle.js': ['test-built/**/*.js']
         },
         options: {
+          external: ['react/lib/ReactContext', 'react/lib/ExecutionEnvironment'],
           verbose: true
         }
       },
@@ -75,6 +76,7 @@ module.exports = function (grunt) {
           'canon-react.js': ['transpiled/index.js']
         },
         options: {
+          external: ['react/lib/ReactContext', 'react/lib/ExecutionEnvironment'],
           transform: [ 'browserify-shim' ],
           browserifyOptions: {
             standalone: 'canonReact'
@@ -86,6 +88,7 @@ module.exports = function (grunt) {
           'demo/bundle.js': ['transpiled/**/*.js'],
         },
         options: {
+          external: ['react/lib/ReactContext', 'react/lib/ExecutionEnvironment'],
           transform: [ 'browserify-shim' ]
         }
       }
@@ -130,7 +133,9 @@ module.exports = function (grunt) {
     'lint:eslint',
     'babel:src',
     'babel:test',
+    'babel:demo',
     'browserify:test',
+    'browserify:demo',
     'browserify:release',
     'uglify:build'
   ]);

--- a/demo/DemoListTableSection.jsx
+++ b/demo/DemoListTableSection.jsx
@@ -1,0 +1,167 @@
+import React from 'react';
+
+import CheckboxColumnHeader from './CheckboxColumnHeader';
+import EmbeddedListTable from './EmbeddedListTable';
+import EmptyOverlay from './EmptyOverlay';
+import ErrorOverlay from './ErrorOverlay';
+import ListTable from './ListTable';
+import ListTableBody from './ListTableBody';
+import ListTableHeader from './ListTableHeader';
+import ListTableRow from './ListTableRow';
+import LoadingOverlay from './LoadingOverlay';
+import OverlayStatus from './OverlayStatus';
+import SortDirection from './SortDirection';
+import StatusColumnHeader from './StatusColumnHeader';
+import TextColumnHeader from './TextColumnHeader';
+
+const DemoListTableHeader = ({ onSort, sortColumn, direction }) => (
+  <ListTableHeader { ...{ onSort, sortColumn, direction } }>
+    <StatusColumnHeader />
+    <CheckboxColumnHeader />
+    <TextColumnHeader columnId="name" className="name" sortable label="Name" />
+    <TextColumnHeader columnId="count" className="count" sortable label="Count" />
+  </ListTableHeader>
+);
+
+DemoListTableHeader.propTypes = {
+  onSort: React.PropTypes.func,
+  sortColumn: React.PropTypes.string,
+  direction: React.PropTypes.oneOf(Object.keys(SortDirection))
+};
+
+const DemoListTableRow = ({ instance }) => (
+  <ListTableRow key={ instance.id } data-model_id={ instance.id } instance={ instance }>
+    <td className="rs-table-status rs-table-status-ok"></td>
+    <td className="rs-table-checkbox"><input type="checkbox" /></td>
+    <td className="rs-table-text">{ instance.name }</td>
+    <td className="rs-table-text">{ instance.count }</td>
+  </ListTableRow>
+);
+
+DemoListTableRow.propTypes = {
+  instance: React.PropTypes.object.isRequired
+};
+
+class DemoListTableSection extends React.Component {
+  constructor() {
+    super();
+
+    this.state = {
+      sortColumn: 'name',
+      direction: SortDirection.ASCENDING
+    };
+
+    this._handleSort = this._handleSort.bind(this);
+  }
+
+  render() {
+    const sortedCollection = this._sort();
+
+    const tableStyle = {width: '500px'};
+
+    return (
+      <div className='rs-detail-section'>
+        <div className='rs-detail-section-header'>
+          <h2>List Table</h2>
+        </div>
+        <div className='rs-detail-section-body'>
+          <h3>List Table</h3>
+          <ListTable style={ tableStyle }>
+            <DemoListTableHeader onSort={ this._handleSort } sortColumn={ this.state.sortColumn } direction={ this.state.direction } />
+            <ListTableBody collection={ sortedCollection }>
+              <DemoListTableRow />
+            </ListTableBody>
+          </ListTable>
+          <hr />
+          <h3>Empty Overlay</h3>
+          <ListTable style={ tableStyle } overlayStatus={ OverlayStatus.EMPTY }>
+            <DemoListTableHeader onSort={ this._handleSort } sortColumn={ this.state.sortColumn } direction={ this.state.direction } />
+            <ListTableBody collection={ [] }>
+              <DemoListTableRow />
+            </ListTableBody>
+          </ListTable>
+          <hr />
+          <h3>Error Overlay</h3>
+          <ListTable style={ tableStyle } overlayStatus={ OverlayStatus.ERROR }>
+            <DemoListTableHeader onSort={ this._handleSort } sortColumn={ this.state.sortColumn } direction={ this.state.direction } />
+            <ListTableBody collection={ [] }>
+              <DemoListTableRow />
+            </ListTableBody>
+          </ListTable>
+          <hr />
+          <h3>Loading Overlay</h3>
+          <ListTable style={ tableStyle } overlayStatus={ OverlayStatus.LOADING }>
+            <DemoListTableHeader onSort={ this._handleSort } sortColumn={ this.state.sortColumn } direction={ this.state.direction } />
+            <ListTableBody collection={ [] }>
+              <DemoListTableRow />
+            </ListTableBody>
+          </ListTable>
+          <hr />
+          <h3>Embedded List Table</h3>
+          <EmbeddedListTable size="medium" style={ tableStyle }>
+            <DemoListTableHeader onSort={ this._handleSort } sortColumn={ this.state.sortColumn } direction={ this.state.direction } />
+            <ListTableBody collection={ sortedCollection }>
+              <DemoListTableRow />
+            </ListTableBody>
+          </EmbeddedListTable>
+        </div>
+      </div>
+    );
+  }
+
+  _handleSort(sortDirection, columnId) {
+    this.setState({
+      sortColumn: columnId,
+      direction: sortDirection
+    });
+  }
+
+  _sort() {
+    return Array.from(COLLECTION).sort(this._compareRows.bind(this));
+  }
+
+  _compareRows(row1, row2) {
+    if (this.state.sortColumn === 'name') {
+      return this._compareStringValues(row1.name, row2.name);
+    } else if (this.state.sortColumn === 'count') {
+      return this._compareNumericValues(row1.count, row2.count);
+    }
+  }
+
+  _compareStringValues(a, b) {
+    if (this.state.direction === SortDirection.ASCENDING) {
+      return a.localeCompare(b);
+    } else {
+      return b.localeCompare(a);
+    }
+  }
+
+  _compareNumericValues(a, b) {
+    if (a === b) {
+      return 0;
+    }
+
+    if (this.state.direction === SortDirection.ASCENDING) {
+      if (a < b) {
+        return -1;
+      } else {
+        return 1;
+      }
+    } else {
+      if (a > b) {
+        return -1;
+      } else {
+        return 1;
+      }
+    }
+  }
+}
+
+const COLLECTION = [
+  {id: 1, name: 'one', count: 1},
+  {id: 2, name: 'two', count: 42},
+  {id: 3, name: 'three', count: 12},
+  {id: 4, name: 'four', count: 6}
+];
+
+export default DemoListTableSection;

--- a/demo/DemoView.jsx
+++ b/demo/DemoView.jsx
@@ -13,6 +13,7 @@ import DemoDetailSection from './DemoDetailSection';
 import DemoDetailSectionCollapsible from './DemoDetailSectionCollapsible';
 import DemoDetailSectionDefaultCollapsed from './DemoDetailSectionDefaultCollapsed';
 import DemoDetailSectionCollapsibleLoading from './DemoDetailSectionCollapsibleLoading';
+import DemoListTableSection from './DemoListTableSection';
 
 class DemoView extends React.Component {
   render() {
@@ -31,6 +32,7 @@ class DemoView extends React.Component {
         <DemoTooltipSection />
         <DemoDropdownSection />
         <DemoFacetsSection />
+        <DemoListTableSection />
       </div>
     );
   }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "babelify": "7.2.0",
     "browserify": "<4.0.0",
     "browserify-shim": "3.8.12",
+    "enzyme": "2.3.0",
     "eslint": "^1.10.3",
     "eslint-plugin-react": "^3.15.0",
     "grunt": "~0.4.2",

--- a/src/CheckboxColumnHeader.jsx
+++ b/src/CheckboxColumnHeader.jsx
@@ -1,0 +1,14 @@
+import classNames from 'classnames';
+
+const CheckboxColumnHeader = (props) => {
+  const classes = classNames(
+    'rs-table-checkbox',
+    props.className
+  );
+
+  return (
+    <th { ...props } className={ classes } />
+  );
+};
+
+export default CheckboxColumnHeader;

--- a/src/EmbeddedListTable.jsx
+++ b/src/EmbeddedListTable.jsx
@@ -1,0 +1,59 @@
+import { Component, PropTypes } from 'react';
+import classNames from 'classnames';
+import ListTableOverlaySelector from './ListTableOverlaySelector';
+import OverlayStatus from './OverlayStatus';
+
+const SIZE_CLASSES = {
+  'small': 'rs-embedded-small',
+  'medium': 'rs-embedded-medium',
+  'large': 'rs-embedded-large'
+};
+
+class EmbeddedListTable extends Component {
+  render() {
+    let classes;
+
+    const {
+      children,
+      className,
+      emptyOverlay,
+      errorOverlay,
+      loadingOverlay,
+      overlayStatus,
+      size
+    } = this.props;
+    const sizeClass = SIZE_CLASSES[size];
+
+    classes = classNames(
+      'rs-embedded-list-table-wrapper',
+      sizeClass,
+      className
+    );
+
+    return (
+      <div { ...this.props } className={ classes }>
+        <table className="rs-list-table rs-embedded-list-table">
+          { children }
+        </table>
+        <ListTableOverlaySelector { ...{overlayStatus, emptyOverlay, errorOverlay, loadingOverlay} } />
+      </div>
+    );
+  }
+}
+
+EmbeddedListTable.defaultProps = {
+  overlayStatus: OverlayStatus.NONE,
+  size: 'small'
+};
+
+EmbeddedListTable.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  emptyOverlay: PropTypes.node,
+  errorOverlay: PropTypes.node,
+  loadingOverlay: PropTypes.node,
+  overlayStatus: PropTypes.oneOf(Object.keys(OverlayStatus)),
+  size: PropTypes.oneOf(Object.keys(SIZE_CLASSES))
+};
+
+export default EmbeddedListTable;

--- a/src/EmptyOverlay.jsx
+++ b/src/EmptyOverlay.jsx
@@ -1,0 +1,14 @@
+import ListTableOverlay from './ListTableOverlay';
+import { PropTypes } from 'react';
+
+const EmptyOverlay = ({ title, subtitle, message }) => (
+  <ListTableOverlay { ...{ title, subtitle, message } } />
+);
+
+EmptyOverlay.propTypes = {
+  title: PropTypes.node.isRequired,
+  subtitle: PropTypes.node,
+  message: PropTypes.node
+};
+
+export default EmptyOverlay;

--- a/src/ErrorOverlay.jsx
+++ b/src/ErrorOverlay.jsx
@@ -1,0 +1,15 @@
+import ListTableOverlay from './ListTableOverlay';
+import { PropTypes } from 'react';
+
+const ErrorOverlay = ({ message }) => (
+  <ListTableOverlay
+    className="rs-table-overlay-error"
+    message={ <span><i className="rs-icon-error-indicator"></i>{ message }</span> }
+  />
+);
+
+ErrorOverlay.propTypes = {
+  message: PropTypes.node.isRequired
+};
+
+export default ErrorOverlay;

--- a/src/ListTable.jsx
+++ b/src/ListTable.jsx
@@ -1,0 +1,45 @@
+import { Component, PropTypes } from 'react';
+import ListTableOverlaySelector from './ListTableOverlaySelector';
+import EmptyOverlay from './EmptyOverlay';
+import ErrorOverlay from './ErrorOverlay';
+import LoadingOverlay from './LoadingOverlay';
+import OverlayStatus from './OverlayStatus';
+
+class ListTable extends Component {
+  render() {
+    const {
+      children,
+      emptyOverlay,
+      errorOverlay,
+      loadingOverlay,
+      overlayStatus
+    } = this.props;
+
+    return (
+      <div { ...this.props } >
+        <table className="rs-list-table">
+          { children }
+        </table>
+        <ListTableOverlaySelector { ...{ overlayStatus, emptyOverlay, errorOverlay, loadingOverlay } } />
+      </div>
+    );
+  }
+}
+
+ListTable.defaultProps = {
+  emptyOverlay: <EmptyOverlay title="Empty List" subtitle="This list is empty" message="There is no data to display" />,
+  errorOverlay: <ErrorOverlay message="There was an error loading data" />,
+  loadingOverlay: <LoadingOverlay />,
+  overlayStatus: OverlayStatus.NONE
+};
+
+ListTable.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  emptyOverlay: PropTypes.node,
+  errorOverlay: PropTypes.node,
+  loadingOverlay: PropTypes.node,
+  overlayStatus: PropTypes.oneOf(Object.keys(OverlayStatus))
+};
+
+export default ListTable;

--- a/src/ListTableBody.jsx
+++ b/src/ListTableBody.jsx
@@ -1,0 +1,40 @@
+import { Component, PropTypes } from 'react';
+
+class ListTableBody extends Component {
+  constructor() {
+    super();
+
+    this._cloneRow = this._cloneRow.bind(this);
+  }
+
+  render() {
+    return (
+      <tbody>
+        { this._cloneRowPerInstance() }
+      </tbody>
+    );
+  }
+
+  _cloneRowPerInstance() {
+    return this.props.collection.map(this._cloneRow);
+  }
+
+  _cloneRow(instance, index, array) {
+    return React.cloneElement(this.props.children, {
+      instance: instance,
+      key: this.props.keyGenerator(instance, index, array)
+    });
+  }
+}
+
+ListTableBody.defaultProps = {
+  keyGenerator: (instance) => (instance.id)
+};
+
+ListTableBody.propTypes = {
+  children: PropTypes.element.isRequired,
+  collection: PropTypes.arrayOf(PropTypes.object).isRequired,
+  keyGenerator: PropTypes.func
+};
+
+export default ListTableBody;

--- a/src/ListTableHeader.jsx
+++ b/src/ListTableHeader.jsx
@@ -1,0 +1,46 @@
+import { Component, PropTypes } from 'react';
+import SortDirection from './SortDirection';
+
+class ListTableHeader extends Component {
+  render() {
+    return (
+      <thead>
+        <tr>{ this._cloneChildren() }</tr>
+      </thead>
+    );
+  }
+
+  _cloneChildren() {
+    const { children, direction, sortColumn } = this.props;
+
+    return React.Children.map(children, (child) => {
+      return React.cloneElement(child,
+        {
+          onSort: this._getSortHandler(child),
+          sortKey: child.props.columnId,
+          direction: (child.props.columnId === sortColumn) ? direction : null
+        }
+      );
+    });
+  }
+
+  _getSortHandler(child) {
+    const { onSort } = this.props;
+
+    return (direction) => {
+      onSort(direction, child.props.columnId);
+    };
+  }
+}
+
+ListTableHeader.defaultProps = {
+  onSort: () => {}
+};
+
+ListTableHeader.propTypes = {
+  onSort: PropTypes.func,
+  sortColumn: PropTypes.string,
+  direction: PropTypes.oneOf(Object.keys(SortDirection))
+};
+
+export default ListTableHeader;

--- a/src/ListTableOverlay.jsx
+++ b/src/ListTableOverlay.jsx
@@ -1,0 +1,20 @@
+import classNames from 'classnames';
+import { PropTypes } from 'react';
+
+const ListTableOverlay = ({ title, subtitle, message, className }) => (
+  <div className={ classNames('rs-table-overlay', className) }>
+    <div className="rs-table-overlay-content">
+      { title ? <div className="rs-table-overlay-title">{ title }</div> : null }
+      { subtitle ? <div className="rs-table-overlay-subtitle">{ subtitle }</div> : null }
+      { message ? <div className="rs-table-overlay-message">{ message }</div> : null }
+    </div>
+  </div>
+);
+
+ListTableOverlay.propTypes = {
+  title: PropTypes.node,
+  subtitle: PropTypes.node,
+  message: PropTypes.node
+};
+
+export default ListTableOverlay;

--- a/src/ListTableOverlaySelector.jsx
+++ b/src/ListTableOverlaySelector.jsx
@@ -1,0 +1,31 @@
+import { PropTypes } from 'react';
+import OverlayStatus from './OverlayStatus';
+
+const ListTableOverlaySelector = ({ emptyOverlay, errorOverlay, loadingOverlay, overlayStatus }) => {
+  if (overlayStatus === OverlayStatus.EMPTY) {
+    return emptyOverlay;
+  }
+
+  if (overlayStatus === OverlayStatus.ERROR) {
+    return errorOverlay;
+  }
+
+  if (overlayStatus === OverlayStatus.LOADING) {
+    return loadingOverlay;
+  }
+
+  return <noscript />;
+};
+
+ListTableOverlaySelector.defaultProps = {
+  overlayStatus: OverlayStatus.NONE
+};
+
+ListTableOverlaySelector.propTypes = {
+  emptyOverlay: PropTypes.node,
+  errorOverlay: PropTypes.node,
+  loadingOverlay: PropTypes.node,
+  overlayStatus: PropTypes.oneOf(Object.keys(OverlayStatus))
+};
+
+export default ListTableOverlaySelector;

--- a/src/ListTableRow.jsx
+++ b/src/ListTableRow.jsx
@@ -1,0 +1,19 @@
+import { PropTypes } from 'react';
+
+const ListTableRow = (props) => (
+  <tr { ...props }>{ cloneChildren(props) }</tr>
+);
+
+const cloneChildren = (props) => {
+  const { children, instance } = props;
+
+  return React.Children.map(children, (child) => {
+    return React.cloneElement(child, { instance });
+  });
+};
+
+ListTableRow.propTypes = {
+  instance: PropTypes.object
+};
+
+export default ListTableRow;

--- a/src/LoadingOverlay.jsx
+++ b/src/LoadingOverlay.jsx
@@ -1,0 +1,7 @@
+import ListTableOverlay from './ListTableOverlay';
+
+const LoadingOverlay = () => (
+  <ListTableOverlay className="rs-table-overlay-loading" message="Loading&hellip;" />
+);
+
+export default LoadingOverlay;

--- a/src/OverlayStatus.js
+++ b/src/OverlayStatus.js
@@ -1,0 +1,8 @@
+const OverlayStatus = {
+  EMPTY: 'empty',
+  ERROR: 'error',
+  LOADING: 'loading',
+  NONE: 'none'
+};
+
+export default OverlayStatus;

--- a/src/SortDirection.js
+++ b/src/SortDirection.js
@@ -1,0 +1,6 @@
+const SortDirection = {
+  ASCENDING: 'asc',
+  DESCENDING: 'desc'
+};
+
+export default SortDirection;

--- a/src/StatusColumnHeader.jsx
+++ b/src/StatusColumnHeader.jsx
@@ -1,0 +1,14 @@
+import classNames from 'classnames';
+
+const StatusColumnHeader = (props) => {
+  const classes = classNames(
+    'rs-table-status',
+    props.className
+  );
+
+  return (
+    <th { ...props } className={ classes } />
+  );
+};
+
+export default StatusColumnHeader;

--- a/src/TextColumnHeader.jsx
+++ b/src/TextColumnHeader.jsx
@@ -1,0 +1,64 @@
+import { Component, PropTypes } from 'react';
+import SortDirection from './SortDirection';
+import classNames from 'classnames';
+
+class TextColumnHeader extends Component {
+  render() {
+    let classes;
+    const { label, sortable, direction, className } = this.props;
+
+    if (sortable) {
+      classes = classNames(
+        'rs-table-sort',
+        {
+          'rs-table-sort-asc': direction === SortDirection.ASCENDING,
+          'rs-table-sort-desc': direction === SortDirection.DESCENDING
+        },
+        className
+      );
+
+      return (
+        <th>
+          <a href="#" onClick={ (ev) => { this._handleClick(ev); } } className={ classes }>
+            <span className="rs-table-sort-text">{ label }</span>
+            <span className="rs-table-sort-indicator"></span>
+          </a>
+        </th>
+      );
+    }
+
+    return (
+      <th>
+        <span className={ classNames('rs-table-sort-text', className) }>{ label }</span>
+      </th>
+    );
+  }
+
+  _handleClick(ev) {
+    const { direction } = this.props;
+
+    if (direction === SortDirection.ASCENDING) {
+      this.props.onSort(SortDirection.DESCENDING);
+    } else {
+      this.props.onSort(SortDirection.ASCENDING);
+    }
+
+    ev.preventDefault();
+    ev.stopPropagation();
+  }
+}
+
+TextColumnHeader.defaultProps = {
+  label: '',
+  sortable: false,
+  onSort: () => {}
+};
+
+TextColumnHeader.propTypes = {
+  label: PropTypes.string.isRequired,
+  sortable: PropTypes.bool.isRequired,
+  onSort: PropTypes.func.isRequired,
+  direction: PropTypes.oneOf(Object.keys(SortDirection))
+};
+
+export default TextColumnHeader;

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import Button from './Button';
 import ButtonGroup from './ButtonGroup';
+import CheckboxColumnHeader from './CheckboxColumnHeader';
 import Criteria from './Criteria';
-import Divider from './Divider';
 import DetailItem from './DetailItem';
 import DetailItemKey from './DetailItemKey';
 import DetailItemValue from './DetailItemValue';
@@ -9,9 +9,13 @@ import DetailList from './DetailList';
 import DetailsSection from './DetailsSection';
 import DetailsSectionSubtitle from './DetailsSectionSubtitle';
 import DetailsSectionTitle from './DetailsSectionTitle';
+import Divider from './Divider';
 import Dropdown from './Dropdown';
 import DropdownItem from './DropdownItem';
 import DropdownTrigger from './DropdownTrigger';
+import EmbeddedListTable from './EmbeddedListTable';
+import EmptyOverlay from './EmptyOverlay';
+import ErrorOverlay from './ErrorOverlay';
 import Facet from './Facet';
 import FacetsSection from './FacetsSection';
 import Form from './Form';
@@ -19,18 +23,30 @@ import FormField from './FormField';
 import FormFieldHelp from './FormFieldHelp';
 import FormFieldValidationBlock from './FormFieldValidationBlock';
 import FormPopover from './FormPopover';
+import ListTable from './ListTable';
+import ListTableBody from './ListTableBody';
+import ListTableHeader from './ListTableHeader';
+import ListTableOverlay from './ListTableOverlay';
+import ListTableOverlaySelector from './ListTableOverlaySelector';
+import ListTableRow from './ListTableRow';
+import LoadingOverlay from './LoadingOverlay';
+import OverlayStatus from './OverlayStatus';
 import Popover from './Popover';
 import PopoverBody from './PopoverBody';
 import PopoverFooter from './PopoverFooter';
-import ProcessingIndicator from './ProcessingIndicator';
 import PopoverOverlay from './PopoverOverlay';
+import ProcessingIndicator from './ProcessingIndicator';
 import ProgressBar from './ProgressBar';
+import SortDirection from './SortDirection';
+import StatusColumnHeader from './StatusColumnHeader';
 import StatusIndicator from './StatusIndicator';
+import TextColumnHeader from './TextColumnHeader';
 import TooltipTrigger from './TooltipTrigger';
 
 export {
   Button,
   ButtonGroup,
+  CheckboxColumnHeader,
   Criteria,
   DetailItem,
   DetailItemKey,
@@ -43,6 +59,9 @@ export {
   Dropdown,
   DropdownItem,
   DropdownTrigger,
+  EmbeddedListTable,
+  EmptyOverlay,
+  ErrorOverlay,
   Facet,
   FacetsSection,
   Form,
@@ -50,12 +69,23 @@ export {
   FormFieldHelp,
   FormFieldValidationBlock,
   FormPopover,
+  ListTable,
+  ListTableBody,
+  ListTableHeader,
+  ListTableOverlay,
+  ListTableOverlaySelector,
+  ListTableRow,
+  LoadingOverlay,
+  OverlayStatus,
   Popover,
   PopoverBody,
   PopoverFooter,
-  ProcessingIndicator,
   PopoverOverlay,
+  ProcessingIndicator,
   ProgressBar,
+  SortDirection,
+  StatusColumnHeader,
   StatusIndicator,
+  TextColumnHeader,
   TooltipTrigger
 };

--- a/test/CheckboxColumnHeaderSpec.jsx
+++ b/test/CheckboxColumnHeaderSpec.jsx
@@ -1,0 +1,21 @@
+import { shallow } from 'enzyme';
+import CheckboxColumnHeader from '../transpiled/CheckboxColumnHeader';
+
+describe('CheckboxColumnHeader', () => {
+  it('renders correctly', () => {
+    const header = shallow(
+      <CheckboxColumnHeader />
+    );
+
+    expect(header.type()).toBe('th');
+    expect(header.hasClass('rs-table-checkbox')).toBe(true);
+  });
+
+  it('adds the supplied className', () => {
+    const header = shallow(
+      <CheckboxColumnHeader className="test-class" />
+    );
+
+    expect(header.hasClass('test-class')).toBe(true);
+  });
+});

--- a/test/EmbeddedListTableSpec.jsx
+++ b/test/EmbeddedListTableSpec.jsx
@@ -1,0 +1,49 @@
+import { shallow } from 'enzyme';
+import EmbeddedListTable from '../transpiled/EmbeddedListTable';
+import ListTableOverlaySelector from '../transpiled/ListTableOverlaySelector';
+import OverlayStatus from '../transpiled/OverlayStatus';
+
+describe('EmbeddedListTable', () => {
+  let listTable, overlayStatus, emptyOverlay, errorOverlay, loadingOverlay;
+
+  beforeEach(() => {
+    overlayStatus = OverlayStatus.NONE;
+    emptyOverlay = <span className="empty_overlay">I'm so empty!</span>;
+    errorOverlay = <span className="error_overlay">There was a problem loading your data!</span>;
+    loadingOverlay = <span className="loading_overlay">I'm loading your data!</span>;
+
+    listTable = shallow(
+      <EmbeddedListTable { ...{overlayStatus, emptyOverlay, errorOverlay, loadingOverlay} }>
+        <span className="test-child-1" />
+        <span className="test-child-2" />
+      </EmbeddedListTable>
+    );
+  });
+
+  it('renders a wrapper div', () => {
+    expect(listTable.type()).toBe('div');
+    expect(listTable.hasClass('rs-embedded-list-table-wrapper')).toBe(true);
+  });
+
+  it('renders a table element with the rs-list-table and rs-embedded-list-table classes', () => {
+    const table = listTable.find('table');
+
+    expect(table.length).toBe(1);
+    expect(table.hasClass('rs-list-table')).toBe(true);
+    expect(table.hasClass('rs-embedded-list-table')).toBe(true);
+  });
+
+  it('renders its children', () => {
+    expect(listTable.find('span').length).toBe(2);
+  });
+
+  it('renders a ListTableOverlaySelector with the overlay status and overlays', () => {
+    const selector = listTable.find(ListTableOverlaySelector);
+
+    expect(selector.length).toBe(1);
+    expect(selector.props().overlayStatus).toBe(overlayStatus);
+    expect(selector.props().emptyOverlay).toBe(emptyOverlay);
+    expect(selector.props().errorOverlay).toBe(errorOverlay);
+    expect(selector.props().loadingOverlay).toBe(loadingOverlay);
+  });
+});

--- a/test/EmptyOverlaySpec.jsx
+++ b/test/EmptyOverlaySpec.jsx
@@ -1,0 +1,29 @@
+import { shallow } from 'enzyme';
+import EmptyOverlay from '../transpiled/EmptyOverlay';
+import ListTableOverlay from '../transpiled/ListTableOverlay';
+
+describe('EmptyOverlay', () => {
+  let emptyOverlay, overlay;
+
+  beforeEach(() => {
+    emptyOverlay = shallow(
+      <EmptyOverlay
+        title="This is a title"
+        subtitle="This is a subtitle"
+        message="This is a message"
+      />
+    );
+
+    overlay = emptyOverlay.find(ListTableOverlay);
+  });
+
+  it('renders the ListTableOverlay', () => {
+    expect(overlay.length).toBe(1);
+  });
+
+  it('passes the title, subtitle, and message to the overlay', () => {
+    expect(overlay.props().title).toBe('This is a title');
+    expect(overlay.props().subtitle).toBe('This is a subtitle');
+    expect(overlay.props().message).toBe('This is a message');
+  });
+});

--- a/test/ErrorOverlaySpec.jsx
+++ b/test/ErrorOverlaySpec.jsx
@@ -1,0 +1,39 @@
+import { shallow } from 'enzyme';
+import ErrorOverlay from '../transpiled/ErrorOverlay';
+import ListTableOverlay from '../transpiled/ListTableOverlay';
+
+describe('ErrorOverlay', () => {
+  let errorOverlay, overlay;
+
+  beforeEach(() => {
+    errorOverlay = shallow(
+      <ErrorOverlay message="This is an error message" />
+    );
+
+    overlay = errorOverlay.find(ListTableOverlay);
+  });
+
+  it('renders a root ListTableOverlay', () => {
+    expect(errorOverlay.type()).toBe(ListTableOverlay);
+  });
+
+  it('passes an rs-table-overlay-error className', () => {
+    expect(overlay.props().className).toBe('rs-table-overlay-error');
+  });
+
+  describe('the message', () => {
+    let message;
+
+    beforeEach(() => {
+      message = shallow(overlay.props().message);
+    });
+
+    it('has an error indicator icon', () => {
+      expect(message.find('.rs-icon-error-indicator').length).toBe(1);
+    });
+
+    it('has the expected text', () => {
+      expect(message.text()).toBe('This is an error message');
+    });
+  });
+});

--- a/test/ListTableBodySpec.jsx
+++ b/test/ListTableBodySpec.jsx
@@ -1,0 +1,49 @@
+import { shallow } from 'enzyme';
+import ListTableBody from '../transpiled/ListTableBody';
+
+describe('ListTableBody', () => {
+  let listTableBody;
+
+  const DummyRow = ({ instance }) => (<div>{ instance.name }</div>);
+  const collection = [
+    { id: 1, name: 'one' },
+    { id: 2, name: 'two' }
+  ];
+
+  beforeEach(() => {
+    listTableBody = shallow(
+      <ListTableBody collection={ collection }>
+        <DummyRow />
+      </ListTableBody>
+    );
+  });
+
+  it('wraps the data in a tbody', () => {
+    expect(listTableBody.type()).toEqual('tbody');
+  });
+
+  it('duplicates the child for each object in the collection', () => {
+    expect(listTableBody.find(DummyRow).length).toBe(2);
+  });
+
+  it('passes the objects in the collection as the instance property of the children', () => {
+    expect(listTableBody.find(DummyRow).at(0).prop('instance')).toBe(collection[0]);
+    expect(listTableBody.find(DummyRow).at(1).prop('instance')).toBe(collection[1]);
+  });
+
+  it('passes the id of the objects in the collection to the children', () => {
+    expect(listTableBody.find(DummyRow).at(0).key()).toBe('1');
+    expect(listTableBody.find(DummyRow).at(1).key()).toBe('2');
+  });
+
+  it('generates the key via the passed keyGenerator', () => {
+    listTableBody = shallow(
+      <ListTableBody collection={ collection } keyGenerator={ (instance) => (instance.name) }>
+        <DummyRow />
+      </ListTableBody>
+    );
+
+    expect(listTableBody.find(DummyRow).at(0).key()).toBe('one');
+    expect(listTableBody.find(DummyRow).at(1).key()).toBe('two');
+  });
+});

--- a/test/ListTableHeaderSpec.jsx
+++ b/test/ListTableHeaderSpec.jsx
@@ -1,0 +1,39 @@
+import { shallow } from 'enzyme';
+import ListTableHeader from '../transpiled/ListTableHeader';
+import SortDirection from '../transpiled/SortDirection';
+
+describe('ListTableHeader', () => {
+  let header, row, sortHandler;
+
+  beforeEach(() => {
+    sortHandler = jasmine.createSpy('sortHandler');
+    header = shallow(
+      <ListTableHeader sortColumn="one" direction={ SortDirection.ASCENDING } onSort={ sortHandler }>
+        <th key="one" columnId="one" sortable />
+        <th id="two" />
+      </ListTableHeader>
+    );
+    row = header.find('tr');
+  });
+
+  it('renders a root thead element', () => {
+    expect(header.type()).toBe('thead');
+  });
+
+  it('wraps the headers in a tr element', () => {
+    expect(header.childAt(0).type()).toBe('tr');
+    expect(row.length).toBe(1);
+  });
+
+  it('adds the children', () => {
+    expect(row.children().length).toEqual(2);
+  });
+
+  it('sets the direction property on the sort column', () => {
+    expect(row.childAt(0).props().direction).toEqual(SortDirection.ASCENDING);
+  });
+
+  it('does not set the direction property on the non-sort column', () => {
+    expect(row.childAt(1).props().direction).toEqual(null);
+  });
+});

--- a/test/ListTableOverlaySelectorSpec.jsx
+++ b/test/ListTableOverlaySelectorSpec.jsx
@@ -1,0 +1,65 @@
+import { shallow } from 'enzyme';
+import ListTableOverlaySelector from '../transpiled/ListTableOverlaySelector';
+import OverlayStatus from '../transpiled/OverlayStatus';
+
+describe('ListTableOverlaySelector', () => {
+  it('renders the empty overlay if overlayStatus is EMPTY', () => {
+    const selector = shallow(
+      <ListTableOverlaySelector
+        overlayStatus={ OverlayStatus.EMPTY }
+        emptyOverlay={ <span className="empty_overlay">I'm so empty!</span> }
+        errorOverlay={ <span className="error_overlay">There was a problem loading your data!</span> }
+        loadingOverlay={ <span className="loading_overlay">I'm loading your data!</span> }
+      />
+    );
+
+    expect(selector.find('.empty_overlay').length).toBe(1);
+    expect(selector.find('.error_overlay').length).toBe(0);
+    expect(selector.find('.loading_overlay').length).toBe(0);
+  });
+
+  it('renders the error overlay if overlayStatus is ERROR', () => {
+    const selector = shallow(
+      <ListTableOverlaySelector
+        overlayStatus={ OverlayStatus.ERROR }
+        emptyOverlay={ <span className="empty_overlay">I'm so empty!</span> }
+        errorOverlay={ <span className="error_overlay">There was a problem loading your data!</span> }
+        loadingOverlay={ <span className="loading_overlay">I'm loading your data!</span> }
+      />
+    );
+
+    expect(selector.find('.empty_overlay').length).toBe(0);
+    expect(selector.find('.error_overlay').length).toBe(1);
+    expect(selector.find('.loading_overlay').length).toBe(0);
+  });
+
+  it('renders the loading overlay if overlayStatus is LOADING', () => {
+    const selector = shallow(
+      <ListTableOverlaySelector
+        overlayStatus={ OverlayStatus.LOADING }
+        emptyOverlay={ <span className="empty_overlay">I'm so empty!</span> }
+        errorOverlay={ <span className="error_overlay">There was a problem loading your data!</span> }
+        loadingOverlay={ <span className="loading_overlay">I'm loading your data!</span> }
+      />
+    );
+
+    expect(selector.find('.empty_overlay').length).toBe(0);
+    expect(selector.find('.error_overlay').length).toBe(0);
+    expect(selector.find('.loading_overlay').length).toBe(1);
+  });
+
+  it('does not render an overlay if overlayStatus is NONE', () => {
+    const selector = shallow(
+      <ListTableOverlaySelector
+        overlayStatus={ OverlayStatus.NONE }
+        emptyOverlay={ <span className="empty_overlay">I'm so empty!</span> }
+        errorOverlay={ <span className="error_overlay">There was a problem loading your data!</span> }
+        loadingOverlay={ <span className="loading_overlay">I'm loading your data!</span> }
+      />
+    );
+
+    expect(selector.find('.empty_overlay').length).toBe(0);
+    expect(selector.find('.error_overlay').length).toBe(0);
+    expect(selector.find('.loading_overlay').length).toBe(0);
+  });
+});

--- a/test/ListTableOverlaySpec.jsx
+++ b/test/ListTableOverlaySpec.jsx
@@ -1,0 +1,59 @@
+import { shallow } from 'enzyme';
+import ListTableOverlay from '../transpiled/ListTableOverlay';
+
+describe('ListTableOverlay', () => {
+  let overlay;
+
+  describe('when rendering with all properties', () => {
+    beforeEach(() => {
+      overlay = shallow(
+        <ListTableOverlay
+          title="This is a title"
+          subtitle="This is a subtitle"
+          message="This is a message"
+        />
+      );
+    });
+
+    it('renders the wrapper divs', () => {
+      expect(overlay.find('.rs-table-overlay').length).toBe(1);
+      expect(overlay.find('.rs-table-overlay').find('.rs-table-overlay-content').length).toBe(1);
+    });
+
+    it('renders the title', () => {
+      expect(overlay.find('.rs-table-overlay-title').text()).toBe('This is a title');
+    });
+
+    it('renders the subtitle', () => {
+      expect(overlay.find('.rs-table-overlay-subtitle').text()).toBe('This is a subtitle');
+    });
+
+    it('renders the message', () => {
+      expect(overlay.find('.rs-table-overlay-message').text()).toBe('This is a message');
+    });
+  });
+
+  describe('when the title, subtitle, and message properties are not defined', () => {
+    beforeEach(() => {
+      overlay = shallow(<ListTableOverlay />);
+    });
+
+    it('does not render the title div', () => {
+      expect(overlay.find('.rs-table-overlay-title').length).toBe(0);
+    });
+
+    it('does not render the subtitle div', () => {
+      expect(overlay.find('.rs-table-overlay-subtitle').length).toBe(0);
+    });
+
+    it('does not render the message div', () => {
+      expect(overlay.find('.rs-table-overlay-message').length).toBe(0);
+    });
+  });
+
+  it('adds the supplied class', () => {
+    overlay = shallow(<ListTableOverlay className="blah" />);
+
+    expect(overlay.find('.blah').length).toBe(1);
+  });
+});

--- a/test/ListTableRowSpec.jsx
+++ b/test/ListTableRowSpec.jsx
@@ -1,0 +1,30 @@
+import { shallow } from 'enzyme';
+import ListTableRow from '../transpiled/ListTableRow';
+
+describe('ListTableRow', () => {
+  let row, instance;
+
+  beforeEach(() => {
+    instance = { id: 'abcde-12345', name: 'howdy' };
+    row = shallow(
+      <ListTableRow data-model_id="abcde-12345" instance={ instance }>
+        <td className="id">{ instance.id }</td>
+        <td className="name">{ instance.name }</td>
+      </ListTableRow>
+    );
+  });
+
+  it('renders a root tr element', () => {
+    expect(row.type()).toBe('tr');
+  });
+
+  it('adds the unknown props to the root element', () => {
+    expect(row.props()['data-model_id']).toBe('abcde-12345');
+  });
+
+  it('adds the children with the instance property', () => {
+    expect(row.children().length).toEqual(2);
+    expect(row.childAt(0).props().instance).toEqual(instance);
+    expect(row.childAt(1).props().instance).toEqual(instance);
+  });
+});

--- a/test/ListTableSpec.jsx
+++ b/test/ListTableSpec.jsx
@@ -1,0 +1,43 @@
+import { shallow } from 'enzyme';
+import ListTable from '../transpiled/ListTable';
+import ListTableOverlaySelector from '../transpiled/ListTableOverlaySelector';
+import OverlayStatus from '../transpiled/OverlayStatus';
+
+describe('ListTable', () => {
+  let listTable, overlayStatus, emptyOverlay, errorOverlay, loadingOverlay;
+
+  beforeEach(() => {
+    overlayStatus = OverlayStatus.NONE;
+    emptyOverlay = <span className="empty_overlay">I'm so empty!</span>;
+    errorOverlay = <span className="error_overlay">There was a problem loading your data!</span>;
+    loadingOverlay = <span className="loading_overlay">I'm loading your data!</span>;
+
+    listTable = shallow(
+      <ListTable { ...{overlayStatus, emptyOverlay, errorOverlay, loadingOverlay} }>
+        <span className="test-child-1" />
+        <span className="test-child-2" />
+      </ListTable>
+    );
+  });
+
+  it('renders a table element with the rs-list-table class', () => {
+    const table = listTable.find('table');
+
+    expect(table.length).toBe(1);
+    expect(table.hasClass('rs-list-table')).toBe(true);
+  });
+
+  it('renders its children', () => {
+    expect(listTable.find('span').length).toBe(2);
+  });
+
+  it('renders a ListTableOverlaySelector with the overlay status and overlays', () => {
+    const selector = listTable.find(ListTableOverlaySelector);
+
+    expect(selector.length).toBe(1);
+    expect(selector.props().overlayStatus).toBe(overlayStatus);
+    expect(selector.props().emptyOverlay).toBe(emptyOverlay);
+    expect(selector.props().errorOverlay).toBe(errorOverlay);
+    expect(selector.props().loadingOverlay).toBe(loadingOverlay);
+  });
+});

--- a/test/LoadingOverlaySpec.jsx
+++ b/test/LoadingOverlaySpec.jsx
@@ -1,0 +1,17 @@
+import { shallow } from 'enzyme';
+import LoadingOverlay from '../transpiled/LoadingOverlay';
+import ListTableOverlay from '../transpiled/ListTableOverlay';
+
+describe('LoadingOverlay', () => {
+  let loadingOverlay;
+
+  it('renders correctly', () => {
+    loadingOverlay = shallow(
+      <LoadingOverlay />
+    );
+
+    expect(loadingOverlay.equals(
+      <ListTableOverlay className="rs-table-overlay-loading" message="Loading&hellip;" />
+    )).toBe(true);
+  });
+});

--- a/test/StatusColumnHeaderSpec.jsx
+++ b/test/StatusColumnHeaderSpec.jsx
@@ -1,0 +1,21 @@
+import { shallow } from 'enzyme';
+import StatusColumnHeader from '../transpiled/StatusColumnHeader';
+
+describe('StatusColumnHeader', () => {
+  it('renders correctly', () => {
+    const header = shallow(
+      <StatusColumnHeader />
+    );
+
+    expect(header.type()).toBe('th');
+    expect(header.hasClass('rs-table-status')).toBe(true);
+  });
+
+  it('adds the supplied className', () => {
+    const header = shallow(
+      <StatusColumnHeader className="test-class" />
+    );
+
+    expect(header.hasClass('test-class')).toBe(true);
+  });
+});

--- a/test/TextColumnHeaderSpec.jsx
+++ b/test/TextColumnHeaderSpec.jsx
@@ -1,0 +1,91 @@
+import { shallow } from 'enzyme';
+import SortDirection from '../transpiled/SortDirection';
+import TextColumnHeader from '../transpiled/TextColumnHeader';
+
+describe('TextColumnHeader', () => {
+  let header;
+
+  describe('when the header is not sortable', () => {
+    beforeEach(() => {
+      header = shallow(
+        <TextColumnHeader sortable={ false } label="This is a label" className="test-class" />
+      );
+    });
+
+    it('adds a table header', () => {
+      expect(header.type()).toBe('th');
+    });
+
+    it('adds the text span with the label', () => {
+      expect(header.find('.rs-table-sort-text').text()).toBe('This is a label');
+    });
+
+    it('adds the supplied className', () => {
+      expect(header.find('.rs-table-sort-text').hasClass('test-class')).toBe(true);
+    });
+  });
+
+  describe('when the header is sortable', () => {
+    let sortSpy;
+
+    beforeEach(() => {
+      sortSpy = jasmine.createSpy('onSort');
+
+      header = shallow(
+        <TextColumnHeader sortable direction={ SortDirection.ASCENDING }
+          onSort={ sortSpy } label="This is another label" className="test-class" />
+      );
+    });
+
+    it('adds a table header', () => {
+      expect(header.type()).toBe('th');
+    });
+
+    it('adds a link with the rs-table-sort class', () => {
+      expect(header.find('a').length).toBe(1);
+      expect(header.find('a').hasClass('rs-table-sort')).toBe(true);
+    });
+
+    it('adds the supplied className', () => {
+      expect(header.find('a').hasClass('test-class')).toBe(true);
+    });
+
+    it('does not adds the ascending class', () => {
+      expect(header.find('a').hasClass('rs-table-sort-asc')).toBe(true);
+    });
+
+    it('adds the text span with the label', () => {
+      expect(header.find('.rs-table-sort-text').text()).toBe('This is another label');
+    });
+
+    it('adds the sort indicator spacing span', () => {
+      expect(header.find('.rs-table-sort-indicator').length).toBe(1);
+    });
+
+    describe('when the sort link is clicked', () => {
+      let event;
+
+      beforeEach(() => {
+        const clickHandler = header.find('a').props().onClick;
+        event = {
+          preventDefault: jasmine.createSpy('preventDefault'),
+          stopPropagation: jasmine.createSpy('stopPropagation')
+        };
+
+        clickHandler(event);
+      });
+
+      it('reverses the direction', () => {
+        expect(sortSpy).toHaveBeenCalledWith(SortDirection.DESCENDING);
+      });
+
+      it('prevents the default link behavior', () => {
+        expect(event.preventDefault).toHaveBeenCalled();
+      });
+
+      it('stops the event propagation', () => {
+        expect(event.stopPropagation).toHaveBeenCalled();
+      });
+    });
+  });
+});


### PR DESCRIPTION
# List Table

Tables are described at http://rackerlabs.github.io/canon/ui-components/#tables. A working table example can be found in DemoListTableSection.jsx.

![screen shot 2016-07-15 at 11 34 52 am](https://cloud.githubusercontent.com/assets/1039525/16879917/b3c90836-4a80-11e6-98c8-bc2783975356.png)

![screen shot 2016-07-15 at 11 35 37 am](https://cloud.githubusercontent.com/assets/1039525/16879938/c8e23dfa-4a80-11e6-8c42-056a4defb551.png)

List tables and embedded list tables are similar, except for the component wrapping them. The regular list table is not wrapped in a border, while the embedded list table has a fixed size and is wrapped in a border.

## Wrapper components

The main component for a list table is `ListTable`, and the main component for the embedded list table is `EmbeddedListTable`. Both of these components take the following properties:

- `overlayStatus` - takes a value of 'none', 'empty', 'error', or 'loading', and describes what overlay should be shown on the table.
- `emptyOverlay` - an `EmptyOverlay` component describing the table's empty state.
- `errorOverlay` - an `ErrorOverlay` component describing the table's error state.
- `loadingOverlay` - a `LoadingOverlay` component describing the table's loading state.

The `EmbeddedListTable` takes an additional property, `size`, which can take the values 'small', 'medium', and 'large', and which specifies how tall the embedded list table will be. These correspond to the small, medium, and large sizes described in http://rackerlabs.github.io/canon/ui-components/#tables for the embedded list table.

In addition, there is an `OverlayStatus` enum that contains the values `NONE`, `EMPTY`, `ERROR`, and `LOADING`, and which can be used for the `overlayStatus` values.  

## ListTableHeader

The `ListTableHeader` component specifies how the table header is rendered, as well as how sorting is handled. The children of the `ListTableHeader` are assumed to be `th` components or a component that will resolve to a `th` component that describes a specific header cell. For instance, a valid `ListTableHeader` is:

```
<ListTableHeader>
  <th className="rs-table-status" />
  <th className="rs-table-sort-text">Name</th>
</ListTableHeader>
``` 

There are several predefined header cell components that implement behavior that conforms to the `th` behavior described for canon-react. These are:

- `CheckboxColumnHeader`
- `StatusColumnHeader`
- `TextColumnHeader` - implements sortable behavior, calls the onSort callback when clicked, displays the sort direction indicator.

When a collection of objects is passed to the list table, it is assumed to be in the order that the user of the component wants it in. The `ListTableHeader` takes the following properties for handling sorting:

- `onSort` - a callback function that is called with the current sort direction and columnId for a sortable header. Any header that has the `sortable` boolean property will be sortable, although the `TextColumnHeader` is the only predefined header that supports that property out of the box. If the header is sortable, it must also support the `columnId` property.
- `sortColumn` - the `columnId` for the column that the collection is sorted by.
- `direction` - current sort direction, either 'asc' or 'desc'.  There is a `SortDirection` enum with values `ASCENDING` and `DESCENDING`, which may be used for the direction value.

## ListTableBody

The `ListTableBody` component takes a collection of data, and then for each object in the collection, it clones its children and passes the object as the child's `instance` property.

```
const collection = [
  {id: 1, name: 'one', count: 1},
  {id: 2, name: 'two', count: 42},
  {id: 3, name: 'three', count: 12},
  {id: 4, name: 'four', count: 6}
];

<ListTableBody collection={ collection }>
  <ListTableRow data-model_id={ instance.id } instance={ instance }>
    <td className="rs-table-status rs-table-status-ok"></td>
    <td className="rs-table-checkbox"><input type="checkbox" /></td>
    <td className="rs-table-text">{ instance.name }</td>
    <td className="rs-table-text">{ instance.count }</td>
  </ListTableRow>
</ListTableBody>
```

The `ListTableRow` component is a convenience for passing the `instance` property to each of its children, but in this case, one could just as easily have used a `tr`. The `ListTableBody` will also set the `key` property for the cloned children. By default, this will be the `id` of the instance. If the instance does not have a unique `id` property, then another unique property can be supplied by setting the `keyGenerator` property on the `ListTableBody`.

# Overlays

There are three predefined Overlay components, the `EmptyOverlay`, the `ErrorOverlay`, and the `LoadingOverlay`. Each of them is intended as a default overlay for the `ListTable` and `EmbeddedListTable` wrapper components. There is also a base `ListTableOverlay` which each of these predefined overlays uses, and which may be used if the table needs some non-default overlay behavior.

![screen shot 2016-07-15 at 11 35 06 am](https://cloud.githubusercontent.com/assets/1039525/16879954/d8da25ba-4a80-11e6-89e0-bc5a287e323f.png)
![screen shot 2016-07-15 at 11 35 19 am](https://cloud.githubusercontent.com/assets/1039525/16879953/d8d651b0-4a80-11e6-968b-2354f725a408.png)
![screen shot 2016-07-15 at 11 35 28 am](https://cloud.githubusercontent.com/assets/1039525/16879952/d8d13d9c-4a80-11e6-8f0f-a29263e1277f.png)
