### PR TITLE
fix form: expose rs-form-horizontal as optional

### DIFF
--- a/demo/DemoFormPopover.jsx
+++ b/demo/DemoFormPopover.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import FormField from './FormField';
 import FormPopover from './FormPopover';
 
-class DemoPopover extends React.Component {
+class DemoFormPopover extends React.Component {
   render() {
     return (
       <FormPopover {...this.props} >
@@ -15,4 +15,4 @@ class DemoPopover extends React.Component {
   }
 }
 
-export default DemoPopover;
+export default DemoFormPopover;

--- a/demo/DemoPopoverSection.jsx
+++ b/demo/DemoPopoverSection.jsx
@@ -17,7 +17,9 @@ class DemoPopoverSection extends React.Component {
       bottomRightFunctionPopoverOpen: false,
       bottomLeftModalPopoverOpen: false,
       formPopoverOpen: false,
-      formPopoverSubmitting: false
+      formPopoverSubmitting: false,
+      topAlignedFormPopoverOpen: false,
+      topAlignedFormPopoverSubmitting: false
     };
   }
 
@@ -95,6 +97,25 @@ class DemoPopoverSection extends React.Component {
                     isOpen={ this.state.formPopoverOpen }
                     onSubmit={ () => { this.setState({formPopoverSubmitting: true}) } }
                     onRequestClose={ () => { this.setState({formPopoverOpen: false}) } } />
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <span>
+                    To top align the content on a submittable popover declare the 'horizontal' prop as false:
+                  </span>
+                  <br>
+                  <Button id="top-aligned-form-popover-button-id" onClick={() => { this.setState({ topAlignedFormPopoverOpen: true, topAlignedFormPopoverSubmitting: false }) } }>
+                    Top Aligned Content
+                  </Button>
+                  <DemoFormPopover
+                    placement="right"
+                    horizontal={ false }
+                    processing={ this.state.topAlignedFormPopoverSubmitting }
+                    target={ () => document.getElementById('top-aligned-form-popover-button-id') }
+                    isOpen={ this.state.topAlignedFormPopoverOpen }
+                    onSubmit={ () => { this.setState({ topAlignedFormPopoverSubmitting: true }) } }
+                    onRequestClose={ () => { this.setState({topAlignedFormPopoverOpen: false }) } } />
                 </td>
               </tr>
             </tbody>

--- a/src/Form.jsx
+++ b/src/Form.jsx
@@ -15,23 +15,31 @@ export default class Form extends React.Component {
 
     sizeClass = SIZE_CLASSES[this.props.size];
     classes = classNames(
-      'rs-form-horizontal',
-      sizeClass,
-      this.props.create ? 'rs-form-create' : undefined,
-      this.props.className
+      {
+        'rs-form-create': this.props.create,
+        'rs-form-horizontal': this.props.horizontal
+      },
+      this.props.className,
+      sizeClass
     );
 
     return (
-      <form {...this.props} className={classes}>
-        {this.props.children}
+      <form { ...this.props } className={ classes }>
+        { this.props.children }
       </form>
     );
   }
 }
 
 Form.propTypes = {
-  create: React.PropTypes.boolean,
+  create: React.PropTypes.bool,
   className: React.PropTypes.string,
+  horizontal: React.PropTypes.bool,
   size: React.PropTypes.oneOf(Object.keys(SIZE_CLASSES)),
   children: React.PropTypes.node.isRequired
+};
+
+Form.defaultProps = {
+  create: false,
+  horizontal: true
 };

--- a/src/FormPopover.jsx
+++ b/src/FormPopover.jsx
@@ -25,17 +25,17 @@ class FormPopover extends React.Component {
     delete popoverProps.children;
 
     return (
-      <Popover {...this.props} >
+      <Popover { ...this.props }>
         <PopoverOverlay>
-          <Form onsubmit={this.props.onSubmit} size={this.props.formSize} >
+          <Form onsubmit={ this.props.onSubmit } size={ this.props.formSize } horizontal={ this.props.horizontal }>
             <PopoverBody>
-              {this.props.children}
+              { this.props.children }
             </PopoverBody>
             <PopoverFooter>
-              {submitComponent}
-              {cancelComponent}
+              { submitComponent }
+              { cancelComponent }
               <ProcessingIndicator hidden={ !this.props.processing }/>
-              <FormFieldValidationBlock value={this.props.error} />
+              <FormFieldValidationBlock value={ this.props.error } />
             </PopoverFooter>
           </Form>
         </PopoverOverlay>
@@ -61,6 +61,7 @@ class FormPopover extends React.Component {
 FormPopover.propTypes = {
   // form
   formSize: React.PropTypes.string,
+  horizontal: React.PropTypes.bool,
   error: React.PropTypes.node,
   processing: React.PropTypes.bool.isRequired,
   onSubmit: React.PropTypes.func.isRequired,
@@ -78,6 +79,7 @@ FormPopover.propTypes = {
 
 FormPopover.defaultProps = {
   error: null,
+  horizontal: true,
   cancelButton: <Button canonStyle="link">Cancel</Button>,
   submitButton: <Button canonStyle="primary">Submit</Button>,
   processing: false,

--- a/test/FormPopoverSpec.jsx
+++ b/test/FormPopoverSpec.jsx
@@ -21,7 +21,7 @@ describe('FormPopover', () => {
     jasmine.getFixtures().cleanUp();
   });
 
-  const renderPopover  = (popoverProps) => {
+  const renderPopover = (popoverProps) => {
     ReactDOM.render(
       <FormPopover
         onRequestClose={onCancel}
@@ -108,7 +108,22 @@ describe('FormPopover', () => {
   });
 
   it('passes errors to the validation block', () => {
-    renderPopover({ error: 'this is a test error message'});
+    renderPopover({ error: 'this is a test error message' });
     expect(document.querySelector('.rs-validation-block').textContent).toBe(' this is a test error message');
+  });
+
+  it('passes the formSize prop to the form', () => {
+    renderPopover({ formSize: 'medium' });
+    expect(document.querySelector('form')).toHaveClass('rs-form-medium');
+  });
+
+  it('passes the horizontal prop to the form', () => {
+    renderPopover({ horizontal: false });
+    expect(document.querySelector('form')).not.toHaveClass('rs-form-horizontal');
+  });
+
+  it('passes the horizontal prop defaulting to true to the form', () => {
+    renderPopover();
+    expect(document.querySelector('form')).toHaveClass('rs-form-horizontal');
   });
 });

--- a/test/FormSpec.jsx
+++ b/test/FormSpec.jsx
@@ -30,6 +30,16 @@ describe('Form', () => {
     expect(ReactDOM.findDOMNode(form)).not.toHaveClass('rs-form-create');
   });
 
+  it('adds the horizontal class', () => {
+    form = TestUtils.renderIntoDocument(<Form horizontal>test</Form>);
+    expect(ReactDOM.findDOMNode(form)).toHaveClass('rs-form-horizontal');
+  });
+
+  it('does not add the horizontal class if horizontal is false', () => {
+    form = TestUtils.renderIntoDocument(<Form horizontal={ false }>test</Form>);
+    expect(ReactDOM.findDOMNode(form)).not.toHaveClass('rs-form-horizontal');
+  });
+
   it('adds passed-in class names to the default ones', () => {
     form = TestUtils.renderIntoDocument(<Form className="some-nonsense">test</Form>);
     expect(ReactDOM.findDOMNode(form)).toHaveClass('some-nonsense');


### PR DESCRIPTION
as the FormPopover component consumes the Form component, exposing the rs-form-horizontal class as optional is critical in the case of top aligned field labels as documented in Canon