### PR TITLE
chore(release): v 0.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Version 0.13.2
+1. Render `Tooltip` subtree component into a container so it will receive the context from its parent.
+
 ### Version 0.13.1
 1. allow the horizontal layout of a form to be configurable
 2. export form components

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "canon-react",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Rackspace Canon components built with React",
   "repository": {
     "type": "git",


### PR DESCRIPTION
1. Render `Tooltip` subtree component into a container so it will receive the context from its parent.