### PR TITLE
Fix FormPopover error display [ready]

### DIFF
--- a/demo/DemoPopoverSection.jsx
+++ b/demo/DemoPopoverSection.jsx
@@ -19,7 +19,9 @@ class DemoPopoverSection extends React.Component {
       formPopoverOpen: false,
       formPopoverSubmitting: false,
       topAlignedFormPopoverOpen: false,
-      topAlignedFormPopoverSubmitting: false
+      topAlignedFormPopoverSubmitting: false,
+      formPopoverErrorOpen: false,
+      formPopoverErrorSubmitting: false
     };
   }
 
@@ -89,14 +91,14 @@ class DemoPopoverSection extends React.Component {
               </tr>
               <tr>
                 <td>
-                  <Button id="form-popover-button-id" onClick={() => { this.setState({formPopoverOpen: true, formPopoverSubmitting: false}) } }>Submittable</Button>
+                  <Button id="form-popover-button-id" onClick={() => { this.setState({ formPopoverOpen: true, formPopoverSubmitting: false }) } }>Submittable</Button>
                   <DemoFormPopover
                     placement="right"
-                    processing={this.state.formPopoverSubmitting}
+                    processing={ this.state.formPopoverSubmitting }
                     target={ () => document.getElementById('form-popover-button-id') }
                     isOpen={ this.state.formPopoverOpen }
-                    onSubmit={ () => { this.setState({formPopoverSubmitting: true}) } }
-                    onRequestClose={ () => { this.setState({formPopoverOpen: false}) } } />
+                    onSubmit={ () => { this.setState({ formPopoverSubmitting: true }) } }
+                    onRequestClose={ () => { this.setState({ formPopoverOpen: false }) } } />
                 </td>
               </tr>
               <tr>
@@ -116,6 +118,19 @@ class DemoPopoverSection extends React.Component {
                     isOpen={ this.state.topAlignedFormPopoverOpen }
                     onSubmit={ () => { this.setState({ topAlignedFormPopoverSubmitting: true }) } }
                     onRequestClose={ () => { this.setState({topAlignedFormPopoverOpen: false }) } } />
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <Button id="form-popover-error-button-id" onClick={() => { this.setState({ formPopoverErrorOpen: true, formPopoverErrorSubmitting: false }) } }>Submittable with Error</Button>
+                  <DemoFormPopover
+                    placement="right"
+                    error="There has been an error processing your request."
+                    processing={ this.state.formPopoverErrorSubmitting }
+                    target={ () => document.getElementById('form-popover-error-button-id') }
+                    isOpen={ this.state.formPopoverErrorOpen }
+                    onSubmit={ () => { this.setState({ formPopoverErrorSubmitting: true }) } }
+                    onRequestClose={ () => { this.setState({ formPopoverErrorOpen: false }) } } />
                 </td>
               </tr>
             </tbody>

--- a/src/ErrorIndicator.jsx
+++ b/src/ErrorIndicator.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default class ErrorIndicator extends React.Component {
+  render() {
+    return this.props.value ? (
+      <div className="rs-status-error">
+        {this.props.value}
+      </div>
+    ) : null;
+  }
+}
+
+ErrorIndicator.propTypes = {
+  value: React.PropTypes.node
+};

--- a/src/FormPopover.jsx
+++ b/src/FormPopover.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
+
 import Button from './Button';
+import ErrorIndicator from './ErrorIndicator';
 import Form from './Form';
-import FormFieldValidationBlock from './FormFieldValidationBlock';
 import Popover from './Popover';
-import PopoverOverlay from './PopoverOverlay';
 import PopoverBody from './PopoverBody';
 import PopoverFooter from './PopoverFooter';
+import PopoverOverlay from './PopoverOverlay';
 import ProcessingIndicator from './ProcessingIndicator';
 
 class FormPopover extends React.Component {
@@ -32,10 +33,10 @@ class FormPopover extends React.Component {
               { this.props.children }
             </PopoverBody>
             <PopoverFooter>
+              <ErrorIndicator value={ this.props.error }/>
               { submitComponent }
               { cancelComponent }
               <ProcessingIndicator hidden={ !this.props.processing }/>
-              <FormFieldValidationBlock value={ this.props.error } />
             </PopoverFooter>
           </Form>
         </PopoverOverlay>

--- a/test/ErrorIndicatorSpec.jsx
+++ b/test/ErrorIndicatorSpec.jsx
@@ -1,0 +1,24 @@
+import ErrorIndicator from '../transpiled/ErrorIndicator';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import TestUtils from 'react-addons-test-utils';
+
+describe('ErrorIndicator', () => {
+  it('displays the validation message', () => {
+    let message, errorIndicator;
+
+    errorIndicator = TestUtils.renderIntoDocument(<ErrorIndicator value="test message" />);
+    message = TestUtils.findRenderedDOMComponentWithClass(errorIndicator, 'rs-status-error');
+    expect(message.getDOMNode().textContent).toBe('test message');
+
+    ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(errorIndicator).parentNode);
+  });
+
+  it('returns null if no field is passed to it', () => {
+    let results, errorIndicator;
+
+    errorIndicator = TestUtils.renderIntoDocument(<ErrorIndicator />);
+    results = TestUtils.scryRenderedDOMComponentsWithClass(errorIndicator, 'rs-status-error');
+    expect(results).toEqual([]);
+  });
+});

--- a/test/FormPopoverSpec.jsx
+++ b/test/FormPopoverSpec.jsx
@@ -4,6 +4,14 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import TestUtils from 'react-addons-test-utils';
 
+import Button from '../transpiled/Button';
+import Form from '../transpiled/Form';
+import ErrorIndicator from '../transpiled/ErrorIndicator';
+import PopoverBody from '../transpiled/PopoverBody';
+import PopoverFooter from '../transpiled/PopoverFooter';
+import PopoverOverlay from '../transpiled/PopoverOverlay';
+import ProcessingIndicator from '../transpiled/ProcessingIndicator';
+
 describe('FormPopover', () => {
   let onCancel, onSubmit, tether;
 
@@ -21,109 +29,177 @@ describe('FormPopover', () => {
     jasmine.getFixtures().cleanUp();
   });
 
-  const renderPopover = (popoverProps) => {
-    ReactDOM.render(
-      <FormPopover
-        onRequestClose={onCancel}
-        onSubmit={onSubmit}
-        target="popover-target"
-        isOpen={true}
-        {...popoverProps}>
-        test
-      </FormPopover>,
-      document.getElementById('container')
-    );
-  };
+  const formPopover = (popoverProps) => (
+    <FormPopover
+      onRequestClose={ onCancel }
+      onSubmit={ onSubmit }
+      target="popover-target"
+      isOpen={ true }
+      { ...popoverProps }>
+      testing child rendering
+    </FormPopover>
+  );
 
-  it('fires the submit callback on click', () => {
-    renderPopover({});
-    TestUtils.Simulate.click(document.querySelector('.rs-btn-primary'));
+  describe('behavior', () => {
+    let eventSpy;
 
-    expect(onSubmit).toHaveBeenCalled();
-  });
+    const renderPopover = (popoverProps) => {
+      ReactDOM.render(
+        formPopover(popoverProps),
+        document.getElementById('container')
+      );
+    };
 
-  it('prevents default behavior on submit', () => {
-    let eventCancelSpy;
-
-    eventCancelSpy = jasmine.createSpy('eventCancelSpy');
-    renderPopover({});
-    TestUtils.Simulate.click(
-      document.querySelector('.rs-btn-primary'),
-      { preventDefault: eventCancelSpy }
-    );
-
-    expect(eventCancelSpy).toHaveBeenCalled();
-  });
-
-  it('fires the request close callback on cancel', () => {
-    renderPopover({});
-    TestUtils.Simulate.click(document.querySelector('.rs-btn-link'));
-
-    expect(onCancel).toHaveBeenCalled();
-  });
-
-  it('prevents default behavior on cancel', () => {
-    let eventCancelSpy;
-
-    eventCancelSpy = jasmine.createSpy('eventCancelSpy');
-    renderPopover({});
-    TestUtils.Simulate.click(
-      document.querySelector('.rs-btn-link'),
-      { preventDefault: eventCancelSpy }
-    );
-
-    expect(eventCancelSpy).toHaveBeenCalled();
-  });
-
-  describe('while processing', () => {
     beforeEach(() => {
-      renderPopover({ processing: true });
+      eventSpy = jasmine.createSpy('eventSpy');
+      renderPopover({});
     });
 
-    it('disables submit', () => {
-      expect(document.querySelector('.rs-btn-primary')).toHaveClass('disabled');
+    it('prevents default behavior on submit', () => {
+      TestUtils.Simulate.click(
+        document.querySelector('.rs-btn-primary'),
+        { preventDefault: eventSpy }
+      );
+
+      expect(eventSpy).toHaveBeenCalled();
     });
 
-    it('hides cancel', () => {
-      expect(document.querySelector('.rs-btn-link')).not.toBe(null);
+    it('fires the submit callback on click', () => {
+      TestUtils.Simulate.click(document.querySelector('.rs-btn-primary'));
+
+      expect(onSubmit).toHaveBeenCalled();
     });
 
-    it('shows the processing indicator', () => {
-      expect(document.querySelector('.rs-processing-indicator')).not.toHaveClass('rs-hidden');
+    it('prevents default behavior on cancel', () => {
+      TestUtils.Simulate.click(
+        document.querySelector('.rs-btn-link'),
+        { preventDefault: eventSpy }
+      );
+
+      expect(eventSpy).toHaveBeenCalled();
+    });
+
+    it('fires the request close callback on cancel', () => {
+      TestUtils.Simulate.click(document.querySelector('.rs-btn-link'));
+
+      expect(onCancel).toHaveBeenCalled();
     });
   });
 
-  it('enables submit', () => {
-    renderPopover({});
-    expect(document.querySelector('.rs-btn-primary')).not.toHaveClass('disabled');
-  });
+  describe('rendering', () => {
+    let popover, popoverOverlay, form, popoverBody, popoverFooter, errorIndicator,
+      submit, cancel, processingIndicator;
 
-  it('shows cancel', () => {
-    renderPopover({});
-    expect(document.querySelector('.rs-btn-link')).not.toHaveClass('rs-hidden');
-  });
+    const shallowRenderPopover = (popoverProps) => {
+      const renderer = TestUtils.createRenderer();
+      renderer.render(formPopover(popoverProps));
 
-  it('hides the processing indicator', () => {
-    expect(document.querySelector('.rs-processing-indicator')).toBe(null);
-  });
+      popover = renderer.getRenderOutput();
+      popoverOverlay = popover.props.children;
+      form = popoverOverlay.props.children;
+      [ popoverBody, popoverFooter ] = form.props.children;
+      [ errorIndicator, submit, cancel, processingIndicator ] = popoverFooter.props.children;
+    };
 
-  it('passes errors to the validation block', () => {
-    renderPopover({ error: 'this is a test error message' });
-    expect(document.querySelector('.rs-validation-block').textContent).toBe(' this is a test error message');
-  });
+    beforeEach(() => {
+      shallowRenderPopover({});
+    });
 
-  it('passes the formSize prop to the form', () => {
-    renderPopover({ formSize: 'medium' });
-    expect(document.querySelector('form')).toHaveClass('rs-form-medium');
-  });
+    it('renders the Popover', () => {
+      expect(popover.type).toBe(Popover);
+    });
 
-  it('passes the horizontal prop to the form', () => {
-    renderPopover({ horizontal: false });
-    expect(document.querySelector('form')).not.toHaveClass('rs-form-horizontal');
-  });
+    it('renders the PopoverOverlay', () => {
+      expect(popoverOverlay.type).toBe(PopoverOverlay);
+    });
 
-  it('passes the horizontal prop defaulting to true to the form', () => {
-    renderPopover();
-    expect(document.querySelector('form')).toHaveClass('rs-form-horizontal');
+    it('renders the Form', () => {
+      expect(form.type).toBe(Form);
+    });
+
+    it('passes the size prop to the form', () => {
+      shallowRenderPopover({ formSize: 'medium' });
+      expect(form.props.size).toBe('medium');
+    });
+
+    it('defaults the horizontal prop to true', () => {
+      expect(form.props.horizontal).toBe(true);
+    });
+
+    it('passes the horizontal prop to the form', () => {
+      shallowRenderPopover({ horizontal: false });
+      expect(form.props.horizontal).toBe(false);
+    });
+
+    it('renders the PopoverBody', () => {
+      expect(popoverBody.type).toBe(PopoverBody);
+    });
+
+    it('renders the children within the PopoverBody', () => {
+      expect(popoverBody.props.children).toEqual('testing child rendering');
+    });
+
+    it('renders the PopoverFooter', () => {
+      expect(popoverFooter.type).toBe(PopoverFooter);
+    });
+
+    it('renders the ErrorIndicator', () => {
+      expect(errorIndicator.type).toBe(ErrorIndicator);
+    });
+
+    it('passes errors to the error indicator', () => {
+      shallowRenderPopover({ error: 'this is a test error message' });
+      expect(errorIndicator.props.value).toBe('this is a test error message');
+    });
+
+    it('renders the submit component', () => {
+      expect(submit.type).toBe(Button);
+    });
+
+    it('has the correct canonStyle on the submit component', () => {
+      expect(submit.props.canonStyle).toBe('primary');
+    });
+
+    it('enables the submit component', () => {
+      expect(submit.props.enabled).toBe(true);
+    });
+
+    it('renders the cancel component', () => {
+      expect(cancel.type).toBe(Button);
+    });
+
+    it('has the correct canonStyle on the cancel component', () => {
+      expect(cancel.props.canonStyle).toBe('link');
+    });
+
+    it('shows the cancel component', () => {
+      expect(cancel.props.hidden).toBe(false);
+    });
+
+    it('renders the ProcessingIndicator', () => {
+      expect(processingIndicator.type).toBe(ProcessingIndicator);
+    });
+
+    it('hides the ProcessingIndicator', () => {
+      expect(processingIndicator.props.hidden).toBe(true);
+    });
+
+    describe('while processing', () => {
+      beforeEach(() => {
+        shallowRenderPopover({ processing: true });
+      });
+
+      it('disables submit', () => {
+        expect(submit.props.enabled).toBe(false);
+      });
+
+      it('hides cancel', () => {
+        expect(cancel.props.hidden).toBe(true);
+      });
+
+      it('shows the processing indicator', () => {
+        expect(processingIndicator.props.hidden).toBe(false);
+      });
+    });
   });
 });


### PR DESCRIPTION
This PR introduces an ErrorIndicator component to be used in cases such as displaying errors on the FormPopover footer. Currently, the error is being displayed through a FormFieldValidationBlock below the button components. However, the Canon classes being used in that component are meaningless outside of a control group, so the error would display as plain black text and the positioning (being rendered below the buttons) would display the error beside of the buttons, widening the popover substantially.

Current (screenshot of code I'm developing within Reach consuming the FormPopover pattern) -
<img width="647" alt="screen shot 2016-07-06 at 12 20 19 pm" src="https://cloud.githubusercontent.com/assets/3260236/16625766/1961719c-4374-11e6-80b7-c200f282bbc8.png">

With changes (rendering error through ErrorIndicator component located above buttons) -
<img width="560" alt="screen shot 2016-07-06 at 12 13 13 pm" src="https://cloud.githubusercontent.com/assets/3260236/16625536/1586615a-4373-11e6-85c4-1ab5678ae860.png">

Canon does not have any patterns surrounding error text outside of tables and validation, so I have settled on the ```rs-status-error``` class here to convey that something is borked and paint it red.
Any thoughts or feedback as to a different approach (including whether or not you think there should be a more appropriate class in the Canon repo) would be appreciated.