### PR TITLE
refactor - normalize styling [not ready]

### DIFF
--- a/src/Criteria.jsx
+++ b/src/Criteria.jsx
@@ -3,17 +3,17 @@ import classNames from 'classnames';
 
 class Criteria extends React.Component {
   render() {
-    let countText, itemClasses;
-
     if (this.props.count !== undefined) {
-      countText = '(' + this.props.count + ')';
+      const countText = `(${ this.props.count })`;
     }
 
-    itemClasses = classNames(
+    const itemClasses = classNames(
       'rs-facet-item',
-      { 'selected': this.props.isSelected },
-      { 'disabled': this.props.disabled },
-      { 'rs-hidden': this.props.hidden}
+      {
+        'selected': this.props.isSelected,
+        'disabled': this.props.disabled,
+        'rs-hidden': this.props.hidden
+      }
     );
 
     return (

--- a/src/DetailsSection.jsx
+++ b/src/DetailsSection.jsx
@@ -7,29 +7,34 @@ class DetailsSection extends React.Component {
     super(props);
 
     this.state = { isCollapsed: props.initialCollapsed };
+    this.toggleCollapsed = this.toggleCollapsed.bind(this);
   }
 
   toggleCollapsed() {
     if (this.props.collapsible) {
-      let newState = !this.state.isCollapsed;
+      const newState = !this.state.isCollapsed;
       this.setState({ isCollapsed: newState });
       this.props.onToggleCollapsed(newState);
     }
   }
 
   render() {
-    let classNames, { collapsible, isLoading } = this.props, { isCollapsed } = this.state;
+    let { collapsible, isLoading } = this.props, { isCollapsed } = this.state;
 
-    classNames = {
-      'rs-collapsible-section collapsed': collapsible && isCollapsed,
-      'rs-collapsible-section expanded': collapsible && !isCollapsed,
-      'loading': isLoading
-    };
+    const classes = classnames(
+      'rs-detail-section',
+      this.props.className,
+      {
+        'rs-collapsible-section': collapsible,
+        'collapsed': collapsible && isCollapsed,
+        'expanded': collapsible && !isCollapsed,
+        'loading': isLoading
+      }
+    );
 
     return (
-      <div { ...this.props }
-        className={ classnames('rs-detail-section', this.props.className, classNames) }>
-        <div className='rs-detail-section-header' onClick={ this.toggleCollapsed.bind(this) }>
+      <div { ...this.props } className={ classes }>
+        <div className='rs-detail-section-header' onClick={ this.toggleCollapsed }>
           { this.props.headers }
           { collapsible ? <div className='rs-caret'></div> : null }
           { this.props.title ? <DetailsSectionTitle>{ this.props.title }</DetailsSectionTitle> : null}

--- a/src/Dropdown.jsx
+++ b/src/Dropdown.jsx
@@ -23,8 +23,8 @@ class Dropdown extends React.Component {
     );
 
     return (
-      <div className={classes} style={dropdownStyle}>
-        <ul className='rs-dropdown-menu visible' style={menuStyle}>
+      <div className={ classes } style={ dropdownStyle }>
+        <ul className='rs-dropdown-menu visible' style={ menuStyle }>
           { this._children() }
         </ul>
       </div>
@@ -44,7 +44,7 @@ Dropdown.defaultProps = {
 };
 
 Dropdown.propTypes = {
-  type: React.PropTypes.oneOf(['primary', 'utility', 'action']),
+  type: React.PropTypes.oneOf(Object.keys(DROPDOWN_TYPES)),
   alignment: React.PropTypes.oneOf(['left', 'right']),
   hideCallback: React.PropTypes.func.isRequired
 };

--- a/src/DropdownItem.jsx
+++ b/src/DropdownItem.jsx
@@ -1,9 +1,29 @@
 import React from 'react';
 import classNames from 'classnames';
 
+const ITEM_TYPE = {
+  'link': 'rs-dropdown-link',
+  'category': 'rs-dropdown-category',
+  'text': 'rs-dropdown-text'
+};
+
 class DropdownItem extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this._handleClick = this._handleClick.bind(this);
+  }
+
   render() {
-    let itemClasses;
+    let itemClasses, itemContentClass, content;
+
+    itemContentClass = ITEM_TYPE[this.props.type];
+
+    if (this.props.type === 'link') {
+      content = <a className={ itemContentClass }>{ this.props.children }</a>;
+    } else {
+      content = <span className={ itemContentClass }>{ this.props.children }</span>;
+    }
 
     itemClasses = classNames(
       'rs-dropdown-item',
@@ -12,28 +32,10 @@ class DropdownItem extends React.Component {
     );
 
     return (
-      <li {...this.props} className={itemClasses} onClick={this._handleClick.bind(this)}>
-        {this._innerElement()}
+      <li { ...this.props } className={ itemClasses } onClick={ this._handleClick }>
+        { content }
       </li>
     );
-  }
-
-  _innerElement() {
-    let innerElement;
-
-    switch(this.props.type) {
-      case 'link':
-        innerElement = <a className='rs-dropdown-link'>{this.props.children}</a>;
-        break;
-      case 'category':
-        innerElement = <span className='rs-dropdown-category'>{this.props.children}</span>;
-        break;
-      case 'text':
-        innerElement = <span className='rs-dropdown-text'>{this.props.children}</span>;
-        break;
-    }
-
-    return innerElement;
   }
 
   _handleClick(e) {
@@ -48,8 +50,8 @@ class DropdownItem extends React.Component {
 
 DropdownItem.defaultProps = {
   enabled: true,
-  onClick: function () {},
-  hideCallback: function () {},
+  onClick: () => {},
+  hideCallback: () => {},
   type: 'link'
 };
 
@@ -57,7 +59,7 @@ DropdownItem.propTypes = {
   enabled: React.PropTypes.bool,
   onClick: React.PropTypes.func,
   hideCallback: React.PropTypes.func,
-  type: React.PropTypes.oneOf(['link', 'category', 'text'])
+  type: React.PropTypes.oneOf(Object.keys(ITEM_TYPE))
 };
 
 export default DropdownItem;

--- a/src/DropdownTrigger.jsx
+++ b/src/DropdownTrigger.jsx
@@ -8,6 +8,8 @@ class DropdownTrigger extends React.Component {
 
     this._documentClickHandler = this._handleDocumentClick.bind(this);
     this._escapeHandler = this._handleEscapePress.bind(this);
+    this._onTriggerClick = this._onTriggerClick.bind(this);
+    this._hide = this._hide.bind(this);
 
     this.state = {
       isDropdownDisplayed: false
@@ -18,7 +20,7 @@ class DropdownTrigger extends React.Component {
     let props;
 
     props = {
-      onClick: this._onTriggerClick.bind(this)
+      onClick: this._onTriggerClick
     };
 
     return (
@@ -83,7 +85,7 @@ class DropdownTrigger extends React.Component {
     dropdown = React.cloneElement(
       this.props.dropdown,
       {
-        hideCallback: this._hide.bind(this),
+        hideCallback: this._hide,
         tether: this.props.alignment
       }
     );

--- a/src/Facet.jsx
+++ b/src/Facet.jsx
@@ -7,14 +7,17 @@ class Facet extends React.Component {
   constructor(props) {
     super(props);
 
+    this._handleClear = this._handleClear.bind(this);
+    this._handleSelectionChanged = this._handleSelectionChanged.bind(this);
+    this._toggleShowLess = this._toggleShowLess.bind(this);
+
     this.state = {
       criteriaTruncated: props.truncationEnabled
     };
   }
 
   render() {
-    let criteriaElements, clearLinkClasses, facetToggler,
-        expandedClass, sectionClasses;
+    let criteriaElements, clearLinkClasses, facetToggler, sectionClasses;
 
     criteriaElements = this._getCriteriaElements();
     facetToggler = this._getMoreOrLessToggle(criteriaElements);
@@ -27,13 +30,16 @@ class Facet extends React.Component {
     expandedClass = this.state.criteriaTruncated ? 'collapsed' : 'expanded';
     sectionClasses = classNames(
       'rs-facet-section',
-      expandedClass
+      {
+        'collapsed': this.state.criteriaTruncated,
+        'expanded': !this.state.criteriaTruncated
+      }
     );
 
     return (
       <div className={ sectionClasses }>
         <div className='rs-facet-section-header'>
-          <div className={ clearLinkClasses } onClick={ this._handleClear.bind(this) }>
+          <div className={ clearLinkClasses } onClick={ this._handleClear }>
             clear
           </div>
           <div className='rs-facet-section-title'>{ this.props.label }</div>
@@ -74,7 +80,7 @@ class Facet extends React.Component {
       return React.cloneElement(child, {
         isSelected: isSelected,
         hidden: isHidden,
-        onSelectionChanged: this._handleSelectionChanged.bind(this)
+        onSelectionChanged: this._handleSelectionChanged
       });
     }, this);
   }
@@ -84,7 +90,7 @@ class Facet extends React.Component {
       return (
         <FacetToggler
           criteriaTruncated={ this.state.criteriaTruncated }
-          onToggleChange={ this._toggleShowLess.bind(this) } />
+          onToggleChange={ this._toggleShowLess } />
       );
     }
     return null;

--- a/src/FacetToggler.jsx
+++ b/src/FacetToggler.jsx
@@ -1,13 +1,17 @@
 import React from 'react';
 
 class FacetToggler extends React.Component {
-  render() {
-    let toggleText;
+  constructor(props) {
+    super(props);
 
-    toggleText = this.props.criteriaTruncated ? 'more' : 'less';
+    this._handleToggleChange = this._handleToggleChange.bind(this);
+  }
+
+  render() {
+    const toggleText = this.props.criteriaTruncated ? 'more' : 'less';
 
     return (
-      <li className='rs-facet-section-toggle' onClick={ this._handleToggleChange.bind(this) }>
+      <li className='rs-facet-section-toggle' onClick={ this._handleToggleChange }>
         <i className='rs-facet-toggle-arrow' />{ toggleText }
       </li>
     );

--- a/src/FacetsSection.jsx
+++ b/src/FacetsSection.jsx
@@ -2,16 +2,22 @@ import React from 'react';
 import classNames from 'classnames';
 
 class FacetsSection extends React.Component {
-  render() {
-    let facets, itemClasses;
+  constructor(props) {
+    super(props);
 
+    this._handleClearAll = this._handleClearAll.bind(this);
+    this._handleSelectionChanged = this._handleSelectionChanged.bind(this);
+    this._handleFacetClear = this._handleFacetClear.bind(this);
+  }
+
+  render() {
     if (!this.props.children) {
       return null;
     }
 
-    facets = this._getFacetElements();
+    const facets = this._getFacetElements();
 
-    itemClasses = classNames(
+    const itemClasses = classNames(
       'rs-facet-clear-link',
       { 'rs-hidden': !Object.keys(this.props.selectedCriteria).length }
     );
@@ -20,7 +26,7 @@ class FacetsSection extends React.Component {
       <span className='rs-facets'>
         <div className='rs-inner'>
           <div className='rs-facet-header'>
-            <div className={ itemClasses } onClick={ this._handleClearAll.bind(this) }>
+            <div className={ itemClasses } onClick={ this._handleClearAll }>
               clear all
             </div>
             <div className='rs-facet-title'>{ this.props.sectionHeader }</div>
@@ -37,9 +43,9 @@ class FacetsSection extends React.Component {
 
       selectedCriteria = this.props.selectedCriteria[child.props.id] || {};
       return React.cloneElement(child, {
-        onSelectionChanged: this._handleSelectionChanged.bind(this),
+        onSelectionChanged: this._handleSelectionChanged,
         selectedCriteria: selectedCriteria,
-        onFacetClear: this._handleFacetClear.bind(this)
+        onFacetClear: this._handleFacetClear
       });
     }, this);
   }

--- a/src/Form.jsx
+++ b/src/Form.jsx
@@ -9,7 +9,7 @@ const SIZE_CLASSES = {
   'xlarge': 'rs-form-xlarge'
 };
 
-export default class Form extends React.Component {
+class Form extends React.Component {
   render() {
     let classes, sizeClass;
 
@@ -43,3 +43,5 @@ Form.defaultProps = {
   create: false,
   horizontal: true
 };
+
+export default Form;

--- a/src/FormField.jsx
+++ b/src/FormField.jsx
@@ -3,15 +3,23 @@ import FormFieldHelp from './FormFieldHelp';
 import FormFieldValidationBlock from './FormFieldValidationBlock';
 import classnames from 'classnames';
 
-export default class FormField extends React.Component {
+class FormField extends React.Component {
   render() {
+    const classes = classnames(
+      'rs-control-group',
+      {
+        'error': this.props.error,
+        'success': this.props.success
+      }
+    );
+
     return (
-      <div className={classnames('rs-control-group', { 'error': this.props.error, 'success': this.props.success })}>
-        <label className="rs-control-label">{this.props.label}</label>
+      <div className={ classes }>
+        <label className="rs-control-label">{ this.props.label }</label>
         <div className="rs-controls">
-          {this.props.children}
-          <FormFieldHelp help={this.props.help} />
-          <FormFieldValidationBlock value={this.props.error || this.props.success} />
+          { this.props.children }
+          <FormFieldHelp help={ this.props.help } />
+          <FormFieldValidationBlock value={ this.props.error || this.props.success } />
         </div>
       </div>
     );
@@ -25,3 +33,5 @@ FormField.propTypes = {
   label: React.PropTypes.node.isRequired,
   children: React.PropTypes.node.isRequired
 };
+
+export default FormField;

--- a/src/FormFieldHelp.jsx
+++ b/src/FormFieldHelp.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
-export default class FormFieldHelp extends React.Component {
+class FormFieldHelp extends React.Component {
   render() {
     return this.props.help ? (
-      <span className="rs-help-block">{this.props.help}</span>
+      <span className="rs-help-block">{ this.props.help }</span>
     ) : null;
   }
 }
@@ -11,3 +11,5 @@ export default class FormFieldHelp extends React.Component {
 FormFieldHelp.propTypes = {
   help: React.PropTypes.node
 };
+
+export default FormFieldHelp;

--- a/src/FormFieldValidationBlock.jsx
+++ b/src/FormFieldValidationBlock.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 
-export default class FormFieldValidationBlock extends React.Component {
+class FormFieldValidationBlock extends React.Component {
   render() {
     return this.props.value ? (
       <span className="rs-validation-block">
-        <i className="rs-validation-indicator"></i> {this.props.value}
+        <i className="rs-validation-indicator"></i> { this.props.value }
       </span>
     ) : null;
   }
@@ -13,3 +13,5 @@ export default class FormFieldValidationBlock extends React.Component {
 FormFieldValidationBlock.propTypes = {
   value: React.PropTypes.node
 };
+
+export default FormFieldValidationBlock;

--- a/src/FormPopover.jsx
+++ b/src/FormPopover.jsx
@@ -10,16 +10,23 @@ import PopoverOverlay from './PopoverOverlay';
 import ProcessingIndicator from './ProcessingIndicator';
 
 class FormPopover extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this._submit = this._submit.bind(this);
+    this._cancel = this._cancel.bind(this);
+  }
+
   render() {
     let submitComponent, cancelComponent, popoverProps;
 
     submitComponent = React.cloneElement(
       this.props.submitButton,
-      { onClick: this._submit.bind(this), enabled: !this.props.processing }
+      { onClick: this._submit, enabled: !this.props.processing }
     );
     cancelComponent = React.cloneElement(
       this.props.cancelButton,
-      { onClick: this._cancel.bind(this), hidden: this.props.processing }
+      { onClick: this._cancel, hidden: this.props.processing }
     );
 
     popoverProps = Object.assign({}, this.props);

--- a/src/Popover.jsx
+++ b/src/Popover.jsx
@@ -4,6 +4,34 @@ import Tether from 'tether';
 import PopoverBackground from './PopoverBackground';
 import classNames from 'classnames';
 
+const PLACEMENT = {
+  'left': {
+    attachment: 'top right',
+    targetAttachment: 'middle left',
+    offset: '38px 20px'
+  },
+  'bottom-left': {
+    attachment: 'top right',
+    targetAttachment: 'bottom left',
+    offset: '-20px -45px'
+  },
+  'bottom-right': {
+    attachment: 'top left',
+    targetAttachment: 'bottom right',
+    offset: '-20px 45px'
+  },
+  'right': {
+    attachment: 'top left',
+    targetAttachment: 'middle right',
+    offset: '38px -20px'
+  },
+  'center': {
+    attachment: 'middle center',
+    targetAttachment: 'middle center',
+    targetModifier: 'visible'
+  }
+};
+
 class Popover extends React.Component {
 
   constructor(props) {
@@ -106,51 +134,7 @@ class Popover extends React.Component {
   }
 
   _getTetherConfig() {
-    let tetherConfig;
-
-    switch (this.props.placement) {
-      case 'left':
-        tetherConfig = {
-          attachment: 'top right',
-          targetAttachment: 'middle left',
-          offset: '38px 20px'
-        };
-        break;
-      case 'bottom-left':
-        tetherConfig = {
-          attachment: 'top right',
-          targetAttachment: 'bottom left',
-          offset: '-20px -45px'
-        };
-        break;
-      case 'bottom-right':
-        tetherConfig = {
-          attachment: 'top left',
-          targetAttachment: 'bottom right',
-          offset: '-20px 45px'
-        };
-        break;
-      case 'right':
-        tetherConfig = {
-          attachment: 'top left',
-          targetAttachment: 'middle right',
-          offset: '38px -20px'
-        };
-        break;
-      case 'center':
-        tetherConfig = {
-          attachment: 'middle center',
-          targetAttachment: 'middle center',
-          targetModifier: 'visible'
-        };
-        break;
-      default:
-        tetherConfig = {
-          attachment: 'top left',
-          targetAttachment: 'middle right',
-          offset: '38px -20px'
-        };
-    }
+    let tetherConfig = PLACEMENT[this.props.placement] || PLACEMENT['right'];
 
     if (this.props.tetherConfig) {
       tetherConfig = Object.assign(tetherConfig, this.props.tetherConfig);
@@ -193,7 +177,7 @@ Popover.propTypes = {
   isModal: React.PropTypes.bool,
   isOpen: React.PropTypes.bool,
   onRequestClose: React.PropTypes.func.isRequired,
-  placement: React.PropTypes.oneOf(['right', 'bottom-right', 'left', 'bottom-left', 'center']),
+  placement: React.PropTypes.oneOf(Object.keys(PLACEMENT)),
   target: React.PropTypes.oneOfType([
     React.PropTypes.string,
     React.PropTypes.func

--- a/src/PopoverBackground.jsx
+++ b/src/PopoverBackground.jsx
@@ -1,15 +1,8 @@
 import React from 'react';
 
 class PopoverBackground extends React.Component {
-
-  constructor(props) {
-    super(props);
-  }
-
   render() {
-    let style;
-
-    style = {
+    const style = {
       'position': 'fixed',
       'left': 0,
       'top': 0,
@@ -22,7 +15,7 @@ class PopoverBackground extends React.Component {
       style['backgroundColor'] = 'rgba(0, 0, 0, 0.5)';
     }
 
-    return (<div className='rs-popover-background-overlay' onClick={this.props.onRequestClose} style={style}></div>);
+    return return <div className='rs-popover-background-overlay' onClick={ this.props.onRequestClose } style={ style } />;
   }
 }
 

--- a/src/PopoverBody.jsx
+++ b/src/PopoverBody.jsx
@@ -2,11 +2,10 @@ import React from 'react';
 import classNames from 'classnames';
 
 class PopoverBody extends React.Component {
-
   render() {
     return (
-      <div className={classNames('rs-popover-body', this.props.className)}>
-        {this.props.children}
+      <div className={ classNames('rs-popover-body', this.props.className) }>
+        { this.props.children }
       </div>
     );
   }

--- a/src/PopoverFooter.jsx
+++ b/src/PopoverFooter.jsx
@@ -3,12 +3,11 @@ import classNames from 'classnames';
 
 import ButtonGroup from './ButtonGroup';
 
-class PopoverFooter extends React.Component {
-
-  render () {
+class PopoverFooter extends React.Component {=
+  render() {
     return (
-      <ButtonGroup className={classNames('rs-popover-footer', this.props.className)}>
-        {this.props.children}
+      <ButtonGroup className={ classNames('rs-popover-footer', this.props.className) }>
+        { this.props.children }
       </ButtonGroup>
     );
   }

--- a/src/PopoverOverlay.jsx
+++ b/src/PopoverOverlay.jsx
@@ -5,41 +5,30 @@ const ARROW_POSITIONS = {
   'right': 'rs-popover-arrow-left-top',
   'bottom-right': 'rs-popover-arrow-top-left',
   'left': 'rs-popover-arrow-right-top',
-  'bottom-left': 'rs-popover-arrow-top-right'
+  'bottom-left': 'rs-popover-arrow-top-right',
+  'center': null
 };
 
 class PopoverOverlay extends React.Component {
-
   _shouldShowArrow() {
     return this.props.placement !== 'center';
   }
 
   render() {
-    let arrowPlacement;
-
-    arrowPlacement = classNames(
+    const arrowPlacement = classNames(
       'rs-popover-arrow',
       ARROW_POSITIONS[this.props.placement]
     );
 
-    if (this._shouldShowArrow()) {
-      return (
-        <div className={this.props.className}>
-          <div className={arrowPlacement}></div>
-          <div className='rs-popover-content'>
-            {this.props.children}
-          </div>
+    return (
+      <div className={ this.props.className }>
+        { this._shouldShowArrow() ? <div className={ arrowPlacement }></div> : null }
+        <div className='rs-popover-content'>
+          { this.props.children }
         </div>
-      );
-    } else {
-      return (
-        <div className={this.props.className}>
-          <div className='rs-popover-content'>
-            {this.props.children}
-          </div>
-        </div>
-      );
-    }
+      </div>
+    );
+
   }
 }
 
@@ -49,9 +38,7 @@ PopoverOverlay.defaultProps = {
 
 PopoverOverlay.propTypes = {
   children: React.PropTypes.node.isRequired,
-  placement: React.PropTypes.oneOf([
-    'right', 'bottom-right', 'left', 'bottom-left', 'center'
-  ])
+  placement: React.PropTypes.oneOf(Object.keys(ARROW_POSITIONS))
 };
 
 export default PopoverOverlay;

--- a/src/ProcessingIndicator.jsx
+++ b/src/ProcessingIndicator.jsx
@@ -2,17 +2,14 @@ import React from 'react';
 import classNames from 'classnames';
 
 class ProcessingIndicator extends React.Component {
-
   render() {
-    let classes;
-
-    classes = classNames(
+    const classes = classNames(
       'rs-processing-indicator',
       { 'rs-hidden': this.props.hidden }
     );
 
     return (
-      <i className={classes}></i>
+      <i className={ classes }></i>
     );
   }
 }

--- a/src/ProgressBar.jsx
+++ b/src/ProgressBar.jsx
@@ -22,33 +22,27 @@ const TYPE_CLASSES = {
 };
 
 class ProgressBar extends React.Component {
-
-  _getSizeClass() {
-     return classNames(
+  render() {
+    const sizeClass = classNames(
       'rs-progress',
       SIZE_CLASSES[this.props.size]
     );
-  }
 
-  _getStatusClass() {
-    return classNames(
+    const statusClass = classNames(
       'rs-bar',
       STATUS_CLASSES[this.props.status],
       TYPE_CLASSES[this.props.type]
     );
-  }
 
-  render() {
     let style, width;
 
-    width = this.props.progress + '%';
-    style = { 'width': width };
+    const style = { 'width': `${this.props.progress}%` };
 
     return (
-      <div className={this._getSizeClass()}>
+      <div className={ sizeClass }>
         <div className='rs-progress-inner'>
-          <div className='rs-segment' style={style}>
-            <div className={this._getStatusClass()}></div>
+          <div className='rs-segment' style={ style }>
+            <div className={ statusClass }></div>
           </div>
         </div>
       </div>
@@ -58,9 +52,9 @@ class ProgressBar extends React.Component {
 
 ProgressBar.propTypes = {
   progress: React.PropTypes.number,
-  status: React.PropTypes.string,
-  type: React.PropTypes.string,
-  size: React.PropTypes.string
+  status: React.PropTypes.oneOf(Object.keys(STATUS_CLASSES)),
+  type: React.PropTypes.oneOf(Object.keys(TYPE_CLASSES)),
+  size: React.PropTypes.oneOf(Object.keys(SIZE_CLASSES))
 };
 
 ProgressBar.defaultProps = {

--- a/src/StatusIndicator.jsx
+++ b/src/StatusIndicator.jsx
@@ -2,33 +2,33 @@ import React from 'react';
 import classNames from 'classnames';
 
 const STATUS_INDICATOR = {
-  'error': 'rs-status rs-status-error',
-  'processing': 'rs-status rs-status-processing',
-  'warning': 'rs-status rs-status-warning',
-  'ok': 'rs-status rs-status-ok',
-  'disabled': 'rs-status rs-status-disabled'
+  'error': 'rs-status-error',
+  'processing': 'rs-status-processing',
+  'warning': 'rs-status-warning',
+  'ok': 'rs-status-ok',
+  'disabled': 'rs-status-disabled'
 };
 
 class StatusIndicator extends React.Component {
 
   render() {
-    let classes;
-
-    classes = classNames(
+    const classes = classNames(
+      'rs-status',
       this.props.className,
       STATUS_INDICATOR[this.props.status],
       { 'rs-hidden': this.props.hidden }
     );
+
     return (
-      <span {...this.props} className={classes}>
-        {this.props.children}
+      <span { ...this.props } className={ classes }>
+        { this.props.children }
       </span>
     );
   }
 }
 
 StatusIndicator.propTypes = {
-  status: React.PropTypes.oneOf(['ok', 'error', 'processing', 'warning', 'disabled']),
+  status: React.PropTypes.oneOf(Object.keys(STATUS_INDICATOR)),
   hidden: React.PropTypes.bool
 };
 

--- a/src/TooltipTrigger.jsx
+++ b/src/TooltipTrigger.jsx
@@ -2,14 +2,54 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import Tether from 'tether';
 
-class TooltipTrigger extends React.Component {
+const PLACEMENT = {
+ 'left': {
+    attachment: 'middle right',
+    targetAttachment: 'middle left'
+  },
+ 'bottom-left': {
+    attachment: 'top right',
+    targetAttachment: 'bottom left'
+  },
+ 'top-left': {
+    attachment: 'bottom right',
+    targetAttachment: 'top left'
+  },
+ 'top': {
+    attachment: 'bottom middle',
+    targetAttachment: 'top middle'
+  },
+ 'bottom': {
+    attachment: 'top middle',
+    targetAttachment: 'bottom middle'
+  },
+ 'right': {
+    attachment: 'middle left',
+    targetAttachment: 'middle right'
+  },
+ 'top-right': {
+    attachment: 'bottom left',
+    targetAttachment: 'top right'
+  },
+ 'bottom-right': {
+    attachment: 'top left',
+    targetAttachment: 'bottom right'
+  }
+};
 
+class TooltipTrigger extends React.Component {
   constructor(props) {
     super(props);
+
     this.state = {
       isTooltipOpen: false,
       isMouseInTooltip: false
     };
+
+    this._mouseEnteringTooltip = this._mouseEnteringTooltip.bind(this);
+    this._mouseLeavingTooltip = this._mouseLeavingTooltip.bind(this);
+    this._showTooltipOnInterval = this._showTooltipOnInterval.bind(this);
+    this._hideTooltipOnInterval = this._hideTooltipOnInterval.bind(this);
   }
 
   componentDidMount() {
@@ -67,9 +107,9 @@ class TooltipTrigger extends React.Component {
     // render the subtree into a container so the popover will receive the context from the parent
     this._tooltipNode = ReactDOM.unstable_renderSubtreeIntoContainer(this, (
       <div className='rs-tooltip-inner'
-        onMouseOver={this._mouseEnteringTooltip.bind(this)}
-        onMouseLeave={this._mouseLeavingTooltip.bind(this)}>
-        {this.props.content}
+        onMouseOver={ this._mouseEnteringTooltip }
+        onMouseLeave={ this._mouseLeavingTooltip }>
+        { this.props.content }
       </div>
     ), this._containerDiv);
 
@@ -83,59 +123,7 @@ class TooltipTrigger extends React.Component {
   }
 
   _getTetherConfig() {
-    let tetherConfig;
-
-    switch (this.props.placement) {
-      case 'left':
-        tetherConfig = {
-          attachment: 'middle right',
-          targetAttachment: 'middle left'
-        };
-        break;
-      case 'bottom-left':
-        tetherConfig = {
-          attachment: 'top right',
-          targetAttachment: 'bottom left'
-        };
-        break;
-      case 'top-left':
-        tetherConfig = {
-          attachment: 'bottom right',
-          targetAttachment: 'top left'
-        };
-        break;
-      case 'top':
-        tetherConfig = {
-          attachment: 'bottom middle',
-          targetAttachment: 'top middle'
-        };
-        break;
-      case 'bottom':
-        tetherConfig = {
-          attachment: 'top middle',
-          targetAttachment: 'bottom middle'
-        };
-        break;
-      case 'right':
-        tetherConfig = {
-          attachment: 'middle left',
-          targetAttachment: 'middle right'
-        };
-        break;
-      case 'top-right':
-        tetherConfig = {
-          attachment: 'bottom left',
-          targetAttachment: 'top right'
-        };
-        break;
-      case 'bottom-right':
-      default:
-        tetherConfig = {
-          attachment: 'top left',
-          targetAttachment: 'bottom right'
-        };
-      break;
-    }
+    let tetherConfig = PLACEMENT[this.props.placement] || PLACEMENT['bottom-right'];
 
     tetherConfig.targetModifier = 'visible';
     tetherConfig.element = ReactDOM.findDOMNode(this._containerDiv);
@@ -148,33 +136,30 @@ class TooltipTrigger extends React.Component {
   }
 
   render() {
-    let triggerProps, showTooltipfunc, hideTooltipFunc;
-
-    showTooltipfunc = this._showTooltipOnInterval.bind(this);
-    hideTooltipFunc = this._hideTooltipOnInterval.bind(this);
-    triggerProps = {
-      onMouseOver: showTooltipfunc,
-      onMouseLeave: hideTooltipFunc,
-      onFocus: showTooltipfunc,
-      onBlur: hideTooltipFunc,
-      ref: 'trigger'
-    };
-
-    return React.cloneElement(React.Children.only(this.props.children), triggerProps);
+    return React.cloneElement(
+      React.Children.only(this.props.children),
+      {
+        onMouseOver: this._showTooltipOnInterval,
+        onMouseLeave: this._hideTooltipOnInterval,
+        onFocus: showTooltipfunc,
+        onBlur: hideTooltipFunc,
+        ref: 'trigger'
+      }
+    );
   }
 
   _showTooltipOnInterval() {
     if (this._hideTimer) {
       clearInterval(this._hideTimer);
     }
-    this._showTimer = setTimeout(() => { this.setState({isTooltipOpen: true}); }, 200);
+    this._showTimer = setTimeout(() => { this.setState({ isTooltipOpen: true}); }, 200);
   }
 
   _hideTooltipOnInterval() {
     if (this._showTimer) {
       clearInterval(this._showTimer);
     }
-    this._hideTimer = setTimeout(() => { this.setState({isTooltipOpen: false}); }, 200);
+    this._hideTimer = setTimeout(() => { this.setState({ isTooltipOpen: false }); }, 200);
   }
 
   _shouldShowTooltip() {
@@ -186,29 +171,20 @@ class TooltipTrigger extends React.Component {
   }
 
   _mouseLeavingTooltip() {
-    this._hideOnLeavingTooltipTimer = setTimeout(() => { this.setState({isMouseInTooltip: false}); }, 250);
+    this._hideOnLeavingTooltipTimer = setTimeout(() => { this.setState({ isMouseInTooltip: false }); }, 250);
   }
 
   _mouseEnteringTooltip() {
     if (this._hideOnLeavingTooltipTimer) {
       clearInterval(this._hideOnLeavingTooltipTimer);
     }
-    this.setState({isMouseInTooltip: true});
+    this.setState({ isMouseInTooltip: true });
   }
 }
 
 TooltipTrigger.propTypes = {
   content: React.PropTypes.node.isRequired,
-  placement: React.PropTypes.oneOf([
-    'right',
-    'bottom-right',
-    'top-right',
-    'top',
-    'left',
-    'bottom-left',
-    'top-left',
-    'bottom'
-  ])
+  placement: React.PropTypes.oneOf(Object.keys(PLACEMENT))
 };
 
 TooltipTrigger.defaultProps = {


### PR DESCRIPTION
This PR is a broad attempt at normalizing our approach to using ```let```, ```const```, propType declarations for object keys, out utilization of the classNames module, and spacing surrounding curly braces. That last one could go in a linting rule I'd say - mebbe I'll do that in another PR.