### PR TITLE
fix (FormPopover propType): fix FormPopover target prop declaration [ready]

### DIFF
--- a/src/FormPopover.jsx
+++ b/src/FormPopover.jsx
@@ -73,7 +73,10 @@ FormPopover.propTypes = {
   children: React.PropTypes.node.isRequired,
   // popover
   isOpen: React.PropTypes.bool.isRequired,
-  target: React.PropTypes.string.isRequired,
+  target: React.PropTypes.oneOfType([
+    React.PropTypes.string,
+    React.PropTypes.func
+  ]).isRequired,
   placement: React.PropTypes.string.isRequired,
   onRequestClose: React.PropTypes.func.isRequired
 };


### PR DESCRIPTION
Previously the target prop on the FormPopover component was defined as being a string. However, the Popover component being rendered by the FormPopover accepts either strings or functions as the target.
This PR changes the FormPopover component to reflect that, preventing the invalid PropType warning from being thrown when the FormPopover is being passed a function as the target (which is a valid means of consuming the Popover and should be reflected in the FormPopover as such).
This is a long explanation for a small change.