### PR TITLE
feat (FormPopover): add optional additional controls to footer [ready]

### DIFF
--- a/demo/DemoPopoverSection.jsx
+++ b/demo/DemoPopoverSection.jsx
@@ -98,7 +98,8 @@ class DemoPopoverSection extends React.Component {
                     target={ () => document.getElementById('form-popover-button-id') }
                     isOpen={ this.state.formPopoverOpen }
                     onSubmit={ () => { this.setState({ formPopoverSubmitting: true }) } }
-                    onRequestClose={ () => { this.setState({ formPopoverOpen: false }) } } />
+                    onRequestClose={ () => { this.setState({ formPopoverOpen: false }) } }
+                    additionalControls={ [ <Button onClick={ (e) => { e.preventDefault(); } } canonStyle="secondary">Opt. Addl Controls</Button> ] } />
                 </td>
               </tr>
               <tr>

--- a/src/FormPopover.jsx
+++ b/src/FormPopover.jsx
@@ -26,7 +26,7 @@ class FormPopover extends React.Component {
     delete popoverProps.children;
 
     return (
-      <Popover { ...this.props }>
+      <Popover { ...popoverProps }>
         <PopoverOverlay>
           <Form onsubmit={ this.props.onSubmit } size={ this.props.formSize } horizontal={ this.props.horizontal }>
             <PopoverBody>
@@ -35,6 +35,7 @@ class FormPopover extends React.Component {
             <PopoverFooter>
               <ErrorIndicator value={ this.props.error }/>
               { submitComponent }
+              { this.props.additionalControls }
               { cancelComponent }
               <ProcessingIndicator hidden={ !this.props.processing }/>
             </PopoverFooter>
@@ -69,6 +70,7 @@ FormPopover.propTypes = {
   // popover layout
   cancelButton: React.PropTypes.element.isRequired,
   submitButton: React.PropTypes.element.isRequired,
+  additionalControls: React.PropTypes.node,
   // popover content
   children: React.PropTypes.node.isRequired,
   // popover
@@ -86,6 +88,7 @@ FormPopover.defaultProps = {
   horizontal: true,
   cancelButton: <Button canonStyle="link">Cancel</Button>,
   submitButton: <Button canonStyle="primary">Submit</Button>,
+  additionalControls: [],
   processing: false,
   isOpen: true,
   placement: 'right'

--- a/test/FormPopoverSpec.jsx
+++ b/test/FormPopoverSpec.jsx
@@ -87,8 +87,8 @@ describe('FormPopover', () => {
   });
 
   describe('rendering', () => {
-    let popover, popoverOverlay, form, popoverBody, popoverFooter, errorIndicator,
-      submit, cancel, processingIndicator;
+    let additionalControls, anotherButton, cancel, errorIndicator, form, popover,
+      popoverBody, popoverFooter, popoverOverlay, processingIndicator, submit;
 
     const shallowRenderPopover = (popoverProps) => {
       const renderer = TestUtils.createRenderer();
@@ -98,11 +98,12 @@ describe('FormPopover', () => {
       popoverOverlay = popover.props.children;
       form = popoverOverlay.props.children;
       [ popoverBody, popoverFooter ] = form.props.children;
-      [ errorIndicator, submit, cancel, processingIndicator ] = popoverFooter.props.children;
+      [ errorIndicator, submit, additionalControls, cancel, processingIndicator ] = popoverFooter.props.children;
     };
 
     beforeEach(() => {
-      shallowRenderPopover({});
+      anotherButton = <Button>Another Button</Button>;
+      shallowRenderPopover({ additionalControls: anotherButton });
     });
 
     it('renders the Popover', () => {
@@ -162,6 +163,10 @@ describe('FormPopover', () => {
 
     it('enables the submit component', () => {
       expect(submit.props.enabled).toBe(true);
+    });
+
+    it('renders the additionalControls if passed in', () => {
+      expect(additionalControls).toBe(anotherButton);
     });
 
     it('renders the cancel component', () => {


### PR DESCRIPTION
Extend FormPopover pattern to optionally render more controls in footer than solely Submit and Cancel. 
This is not an uncommon pattern as popovers can be used as a location to both edit and delete an entity (example from Reach) -
<img width="632" alt="screen shot 2016-07-15 at 11 21 55 am" src="https://cloud.githubusercontent.com/assets/3260236/16879391/66526748-4a7e-11e6-9f13-4330d722f4ab.png">
The popover pictured above exposes both edit functionality as well as disabling/delete functionality.

Screenshot of FormPopover demo -
<img width="496" alt="screen shot 2016-07-15 at 11 21 04 am" src="https://cloud.githubusercontent.com/assets/3260236/16879419/858a8d98-4a7e-11e6-9ec0-2f21abfff972.png">
