### PR TITLE
refactor (normalize styling): normalize use of classname module, other styling

### DIFF
--- a/src/Button.jsx
+++ b/src/Button.jsx
@@ -14,6 +14,12 @@ const BUTTON_TYPES = {
 };
 
 class Button extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this._handleClick = this._handleClick.bind(this);
+  }
+
   render() {
     let classes;
 
@@ -24,17 +30,13 @@ class Button extends React.Component {
       { 'rs-hidden': this.props.hidden }
     );
 
-    if (this.props.canonStyle === 'action') {
-      return (
-        <button {...this.props} className={classes} onClick={this._handleClick.bind(this)}>
-          <span className='rs-cog'></span> {this.props.children} <span className='rs-caret'></span>
-        </button>
-      );
-    }
+    const isActionButton = this.props.canonStyle === 'action';
 
     return (
-      <button {...this.props} className={classes} onClick={this._handleClick.bind(this)}>
-        {this.props.children}
+      <button { ...this.props } className={ classes } onClick={ this._handleClick }>
+        { isActionButton ? [ <span className='rs-cog'/>, ' ' ] : null }
+        { this.props.children }
+        { isActionButton ? [ ' ', <span className='rs-caret'/> ] : null }
       </button>
     );
   }
@@ -51,19 +53,8 @@ class Button extends React.Component {
 Button.propTypes = {
   enabled: React.PropTypes.bool,
   onClick: React.PropTypes.func,
-  canonStyle: React.PropTypes.oneOf([
-    'action',
-    'primary',
-    'link',
-    'login',
-    'secondary',
-    'cog',
-    'delete',
-    'edit',
-    'plus'
-  ]),
-  hidden: React.PropTypes.bool,
-  type: React.PropTypes.string
+  canonStyle: React.PropTypes.oneOf(Object.keys(BUTTON_TYPES)),
+  hidden: React.PropTypes.bool
 };
 
 Button.defaultProps = {

--- a/src/Criteria.jsx
+++ b/src/Criteria.jsx
@@ -2,14 +2,20 @@ import React from 'react';
 import classNames from 'classnames';
 
 class Criteria extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this._handleSelectionChange = this._handleSelectionChange.bind(this);
+  }
+
   render() {
-    let countText, itemClasses;
+    let countText;
 
     if (this.props.count !== undefined) {
       countText = '(' + this.props.count + ')';
     }
 
-    itemClasses = classNames(
+    const itemClasses = classNames(
       'rs-facet-item',
       { 'selected': this.props.isSelected },
       { 'disabled': this.props.disabled },
@@ -18,7 +24,7 @@ class Criteria extends React.Component {
 
     return (
       <span>
-        <li className={ itemClasses } onClick={ this._handleSelectionChange.bind(this) } title={ this.props.label }>
+        <li className={ itemClasses } onClick={ this._handleSelectionChange } title={ this.props.label }>
           <span className={ this.props.iconClass } />
           <div className='rs-facet-label'>{ this.props.label }</div>
           <div className='rs-facet-count'>{ countText }</div>

--- a/src/DetailsSection.jsx
+++ b/src/DetailsSection.jsx
@@ -18,17 +18,22 @@ class DetailsSection extends React.Component {
   }
 
   render() {
-    let classNames, { collapsible, isLoading } = this.props, { isCollapsed } = this.state;
+    let { collapsible, isLoading } = this.props, { isCollapsed } = this.state;
 
-    classNames = {
-      'rs-collapsible-section collapsed': collapsible && isCollapsed,
-      'rs-collapsible-section expanded': collapsible && !isCollapsed,
-      'loading': isLoading
-    };
+    const classes = classnames(
+      'rs-detail-section',
+      this.props.className,
+      {
+        'rs-collapsible-section': collapsible,
+        'collapsed': collapsible && isCollapsed,
+        'expanded': collapsible && !isCollapsed,
+        'loading': isLoading
+      }
+    );
 
     return (
       <div { ...this.props }
-        className={ classnames('rs-detail-section', this.props.className, classNames) }>
+        className={ classes }>
         <div className='rs-detail-section-header' onClick={ this.toggleCollapsed.bind(this) }>
           { this.props.headers }
           { collapsible ? <div className='rs-caret'></div> : null }

--- a/src/Dropdown.jsx
+++ b/src/Dropdown.jsx
@@ -9,22 +9,22 @@ const DROPDOWN_TYPES = {
 
 class Dropdown extends React.Component {
   render() {
-    let dropdownStyle, menuStyle, classes;
+    let menuStyle;
 
-    dropdownStyle = { float: 'left' };
+    const dropdownStyle = { float: 'left' };
 
     if (this.props.alignment) {
       menuStyle = { position: 'static' };
     }
 
-    classes = classNames(
+    const classes = classNames(
       this.props.className,
       DROPDOWN_TYPES[this.props.type]
     );
 
     return (
-      <div className={classes} style={dropdownStyle}>
-        <ul className='rs-dropdown-menu visible' style={menuStyle}>
+      <div className={ classes } style={ dropdownStyle }>
+        <ul className='rs-dropdown-menu visible' style={ menuStyle }>
           { this._children() }
         </ul>
       </div>
@@ -44,7 +44,7 @@ Dropdown.defaultProps = {
 };
 
 Dropdown.propTypes = {
-  type: React.PropTypes.oneOf(['primary', 'utility', 'action']),
+  type: React.PropTypes.oneOf(Object.keys(DROPDOWN_TYPES)),
   alignment: React.PropTypes.oneOf(['left', 'right']),
   hideCallback: React.PropTypes.func.isRequired
 };

--- a/src/DropdownItem.jsx
+++ b/src/DropdownItem.jsx
@@ -1,39 +1,36 @@
 import React from 'react';
 import classNames from 'classnames';
 
-class DropdownItem extends React.Component {
-  render() {
-    let itemClasses;
+const ITEM_TYPE = {
+  'link': <a className='rs-dropdown-link' />,
+  'category': <span className='rs-dropdown-category' />,
+  'text': <span className='rs-dropdown-text' />
+};
 
-    itemClasses = classNames(
+class DropdownItem extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this._handleClick = this._handleClick.bind(this);
+  }
+
+  render() {
+    const itemClasses = classNames(
       'rs-dropdown-item',
       this.props.className,
       { 'disabled': !this.props.enabled }
     );
 
+    const innerElement = React.cloneElement(
+      ITEM_TYPE[this.props.type],
+      { children: this.props.children }
+    );
+
     return (
-      <li {...this.props} className={itemClasses} onClick={this._handleClick.bind(this)}>
-        {this._innerElement()}
+      <li { ...this.props } className={ itemClasses } onClick={ this._handleClick }>
+        { innerElement }
       </li>
     );
-  }
-
-  _innerElement() {
-    let innerElement;
-
-    switch(this.props.type) {
-      case 'link':
-        innerElement = <a className='rs-dropdown-link'>{this.props.children}</a>;
-        break;
-      case 'category':
-        innerElement = <span className='rs-dropdown-category'>{this.props.children}</span>;
-        break;
-      case 'text':
-        innerElement = <span className='rs-dropdown-text'>{this.props.children}</span>;
-        break;
-    }
-
-    return innerElement;
   }
 
   _handleClick(e) {
@@ -48,8 +45,8 @@ class DropdownItem extends React.Component {
 
 DropdownItem.defaultProps = {
   enabled: true,
-  onClick: function () {},
-  hideCallback: function () {},
+  onClick: () => {},
+  hideCallback: () => {},
   type: 'link'
 };
 
@@ -57,7 +54,7 @@ DropdownItem.propTypes = {
   enabled: React.PropTypes.bool,
   onClick: React.PropTypes.func,
   hideCallback: React.PropTypes.func,
-  type: React.PropTypes.oneOf(['link', 'category', 'text'])
+  type: React.PropTypes.oneOf(Object.keys(ITEM_TYPE))
 };
 
 export default DropdownItem;

--- a/src/DropdownTrigger.jsx
+++ b/src/DropdownTrigger.jsx
@@ -8,6 +8,8 @@ class DropdownTrigger extends React.Component {
 
     this._documentClickHandler = this._handleDocumentClick.bind(this);
     this._escapeHandler = this._handleEscapePress.bind(this);
+    this._onTriggerClick = this._onTriggerClick.bind(this);
+    this._hide = this._hide.bind(this);
 
     this.state = {
       isDropdownDisplayed: false
@@ -15,16 +17,12 @@ class DropdownTrigger extends React.Component {
   }
 
   render() {
-    let props;
-
-    props = {
-      onClick: this._onTriggerClick.bind(this)
-    };
-
     return (
       React.cloneElement(
         React.Children.only(this.props.children),
-        props
+        {
+          onClick: this._onTriggerClick
+        }
       )
     );
   }
@@ -41,11 +39,7 @@ class DropdownTrigger extends React.Component {
   }
 
   _onTriggerClick() {
-    if (this.state.isDropdownDisplayed) {
-      this._hide();
-    } else {
-      this._show();
-    }
+    this.state.isDropdownDisplayed ? this._hide() : this._show();
   }
 
   _hide() {
@@ -83,7 +77,7 @@ class DropdownTrigger extends React.Component {
     dropdown = React.cloneElement(
       this.props.dropdown,
       {
-        hideCallback: this._hide.bind(this),
+        hideCallback: this._hide,
         tether: this.props.alignment
       }
     );
@@ -101,8 +95,8 @@ class DropdownTrigger extends React.Component {
     let tetherConfig;
 
     tetherConfig = {
-      attachment: `top ${this.props.alignment}`,
-      targetAttachment: `bottom ${this.props.alignment}`
+      attachment: `top ${ this.props.alignment }`,
+      targetAttachment: `bottom ${ this.props.alignment }`
     };
 
     tetherConfig.element = ReactDOM.findDOMNode(this._containerDiv);

--- a/src/Facet.jsx
+++ b/src/Facet.jsx
@@ -7,25 +7,26 @@ class Facet extends React.Component {
   constructor(props) {
     super(props);
 
+    this._handleClear = this._handleClear.bind(this);
+    this._handleSelectionChanged = this._handleSelectionChanged.bind(this);
+    this._toggleShowLess = this._toggleShowLess.bind(this);
+
     this.state = {
       criteriaTruncated: props.truncationEnabled
     };
   }
 
   render() {
-    let criteriaElements, clearLinkClasses, facetToggler,
-        expandedClass, sectionClasses;
+    const criteriaElements = this._getCriteriaElements();
+    const facetToggler = this._getMoreOrLessToggle(criteriaElements);
 
-    criteriaElements = this._getCriteriaElements();
-    facetToggler = this._getMoreOrLessToggle(criteriaElements);
-
-    clearLinkClasses = classNames(
+    const clearLinkClasses = classNames(
       'rs-facet-clear-link',
       { 'rs-hidden': !this._facetHasSelectedCriteria() }
     );
 
-    expandedClass = this.state.criteriaTruncated ? 'collapsed' : 'expanded';
-    sectionClasses = classNames(
+    const expandedClass = this.state.criteriaTruncated ? 'collapsed' : 'expanded';
+    const sectionClasses = classNames(
       'rs-facet-section',
       expandedClass
     );
@@ -33,7 +34,7 @@ class Facet extends React.Component {
     return (
       <div className={ sectionClasses }>
         <div className='rs-facet-section-header'>
-          <div className={ clearLinkClasses } onClick={ this._handleClear.bind(this) }>
+          <div className={ clearLinkClasses } onClick={ this._handleClear }>
             clear
           </div>
           <div className='rs-facet-section-title'>{ this.props.label }</div>
@@ -61,9 +62,7 @@ class Facet extends React.Component {
   }
 
   _getCriteriaElements() {
-    let index;
-
-    index = 0;
+    let index = 0;
     return React.Children.map(this.props.children, (child) => {
       let isSelected, isTruncated, isHidden;
 
@@ -74,17 +73,19 @@ class Facet extends React.Component {
       return React.cloneElement(child, {
         isSelected: isSelected,
         hidden: isHidden,
-        onSelectionChanged: this._handleSelectionChanged.bind(this)
+        onSelectionChanged: this._handleSelectionChanged
       });
     }, this);
   }
 
   _getMoreOrLessToggle() {
-    if (this.props.truncationEnabled && React.Children.count(this.props.children) > this.props.truncationLength) {
+    const needsToTruncate = React.Children.count(this.props.children) > this.props.truncationLength;
+
+    if (this.props.truncationEnabled && needsToTruncate) {
       return (
         <FacetToggler
           criteriaTruncated={ this.state.criteriaTruncated }
-          onToggleChange={ this._toggleShowLess.bind(this) } />
+          onToggleChange={ this._toggleShowLess } />
       );
     }
     return null;

--- a/src/FacetToggler.jsx
+++ b/src/FacetToggler.jsx
@@ -1,13 +1,17 @@
 import React from 'react';
 
 class FacetToggler extends React.Component {
-  render() {
-    let toggleText;
+  constructor(props) {
+    super(props);
 
-    toggleText = this.props.criteriaTruncated ? 'more' : 'less';
+    this._handleToggleChange = this._handleToggleChange.bind(this);
+  }
+
+  render() {
+    const toggleText = this.props.criteriaTruncated ? 'more' : 'less';
 
     return (
-      <li className='rs-facet-section-toggle' onClick={ this._handleToggleChange.bind(this) }>
+      <li className='rs-facet-section-toggle' onClick={ this._handleToggleChange }>
         <i className='rs-facet-toggle-arrow' />{ toggleText }
       </li>
     );

--- a/src/FacetsSection.jsx
+++ b/src/FacetsSection.jsx
@@ -2,16 +2,22 @@ import React from 'react';
 import classNames from 'classnames';
 
 class FacetsSection extends React.Component {
-  render() {
-    let facets, itemClasses;
+  constructor(props) {
+    super(props);
 
+    this._handleClearAll = this._handleClearAll.bind(this);
+    this._handleSelectionChanged = this._handleSelectionChanged.bind(this);
+    this._handleFacetClear = this._handleFacetClear.bind(this);
+  }
+
+  render() {
     if (!this.props.children) {
       return null;
     }
 
-    facets = this._getFacetElements();
+    const facets = this._getFacetElements();
 
-    itemClasses = classNames(
+    const itemClasses = classNames(
       'rs-facet-clear-link',
       { 'rs-hidden': !Object.keys(this.props.selectedCriteria).length }
     );
@@ -20,7 +26,7 @@ class FacetsSection extends React.Component {
       <span className='rs-facets'>
         <div className='rs-inner'>
           <div className='rs-facet-header'>
-            <div className={ itemClasses } onClick={ this._handleClearAll.bind(this) }>
+            <div className={ itemClasses } onClick={ this._handleClearAll }>
               clear all
             </div>
             <div className='rs-facet-title'>{ this.props.sectionHeader }</div>
@@ -36,11 +42,14 @@ class FacetsSection extends React.Component {
       let selectedCriteria;
 
       selectedCriteria = this.props.selectedCriteria[child.props.id] || {};
-      return React.cloneElement(child, {
-        onSelectionChanged: this._handleSelectionChanged.bind(this),
-        selectedCriteria: selectedCriteria,
-        onFacetClear: this._handleFacetClear.bind(this)
-      });
+      return React.cloneElement(
+        child,
+        {
+          selectedCriteria,
+          onSelectionChanged: this._handleSelectionChanged,
+          onFacetClear: this._handleFacetClear
+        }
+      );
     }, this);
   }
 

--- a/src/Popover.jsx
+++ b/src/Popover.jsx
@@ -4,8 +4,35 @@ import Tether from 'tether';
 import PopoverBackground from './PopoverBackground';
 import classNames from 'classnames';
 
-class Popover extends React.Component {
+const PLACEMENT = {
+  'left': {
+    attachment: 'top right',
+    targetAttachment: 'middle left',
+    offset: '38px 20px'
+  },
+  'bottom-left': {
+    attachment: 'top right',
+    targetAttachment: 'bottom left',
+    offset: '-20px -45px'
+  },
+  'bottom-right': {
+    attachment: 'top left',
+    targetAttachment: 'bottom right',
+    offset: '-20px 45px'
+  },
+  'right': {
+    attachment: 'top left',
+    targetAttachment: 'middle right',
+    offset: '38px -20px'
+  },
+  'center': {
+    attachment: 'middle center',
+    targetAttachment: 'middle center',
+    targetModifier: 'visible'
+  }
+};
 
+class Popover extends React.Component {
   constructor(props) {
     super(props);
 
@@ -36,11 +63,7 @@ class Popover extends React.Component {
   }
 
   _togglePopoverOverlay() {
-    if (this.props.isOpen) {
-      this._show();
-    } else {
-      this._hide();
-    }
+    this.props.isOpen ? this._show() : this._hide();
   }
 
   _hide() {
@@ -79,10 +102,18 @@ class Popover extends React.Component {
     let popover;
 
     this._backgroundDiv.style.display = 'block';
-    ReactDOM.render(<PopoverBackground isModal={ this.props.isModal } onRequestClose={this.props.onRequestClose} />, this._backgroundDiv);
+    ReactDOM.render(
+      <PopoverBackground isModal={ this.props.isModal } onRequestClose={ this.props.onRequestClose } />,
+      this._backgroundDiv
+    );
 
     let containerClasses = this._containerDiv.className.split(' ');
-    this._containerDiv.className = classNames(containerClasses, {'rs-popover': containerClasses.indexOf('rs-popover') < 0});
+    this._containerDiv.className = classNames(
+      containerClasses,
+      {
+        'rs-popover': containerClasses.indexOf('rs-popover') < 0
+      }
+    );
 
     if (!this._tether) {
       this._tether = this._createTether(this._getTetherConfig());
@@ -106,51 +137,7 @@ class Popover extends React.Component {
   }
 
   _getTetherConfig() {
-    let tetherConfig;
-
-    switch (this.props.placement) {
-      case 'left':
-        tetherConfig = {
-          attachment: 'top right',
-          targetAttachment: 'middle left',
-          offset: '38px 20px'
-        };
-        break;
-      case 'bottom-left':
-        tetherConfig = {
-          attachment: 'top right',
-          targetAttachment: 'bottom left',
-          offset: '-20px -45px'
-        };
-        break;
-      case 'bottom-right':
-        tetherConfig = {
-          attachment: 'top left',
-          targetAttachment: 'bottom right',
-          offset: '-20px 45px'
-        };
-        break;
-      case 'right':
-        tetherConfig = {
-          attachment: 'top left',
-          targetAttachment: 'middle right',
-          offset: '38px -20px'
-        };
-        break;
-      case 'center':
-        tetherConfig = {
-          attachment: 'middle center',
-          targetAttachment: 'middle center',
-          targetModifier: 'visible'
-        };
-        break;
-      default:
-        tetherConfig = {
-          attachment: 'top left',
-          targetAttachment: 'middle right',
-          offset: '38px -20px'
-        };
-    }
+    let tetherConfig = PLACEMENT[this.props.placement] || PLACEMENT['right'];
 
     if (this.props.tetherConfig) {
       tetherConfig = Object.assign(tetherConfig, this.props.tetherConfig);
@@ -193,7 +180,7 @@ Popover.propTypes = {
   isModal: React.PropTypes.bool,
   isOpen: React.PropTypes.bool,
   onRequestClose: React.PropTypes.func.isRequired,
-  placement: React.PropTypes.oneOf(['right', 'bottom-right', 'left', 'bottom-left', 'center']),
+  placement: React.PropTypes.oneOf(Object.keys(PLACEMENT)),
   target: React.PropTypes.oneOfType([
     React.PropTypes.string,
     React.PropTypes.func

--- a/src/PopoverOverlay.jsx
+++ b/src/PopoverOverlay.jsx
@@ -5,41 +5,26 @@ const ARROW_POSITIONS = {
   'right': 'rs-popover-arrow-left-top',
   'bottom-right': 'rs-popover-arrow-top-left',
   'left': 'rs-popover-arrow-right-top',
-  'bottom-left': 'rs-popover-arrow-top-right'
+  'bottom-left': 'rs-popover-arrow-top-right',
+  'center': null
 };
 
 class PopoverOverlay extends React.Component {
-
-  _shouldShowArrow() {
-    return this.props.placement !== 'center';
-  }
-
   render() {
-    let arrowPlacement;
-
-    arrowPlacement = classNames(
+    const shouldShowArrow = this.props.placement !== 'center';
+    const arrowPlacement = classNames(
       'rs-popover-arrow',
       ARROW_POSITIONS[this.props.placement]
     );
 
-    if (this._shouldShowArrow()) {
-      return (
-        <div className={this.props.className}>
-          <div className={arrowPlacement}></div>
-          <div className='rs-popover-content'>
-            {this.props.children}
-          </div>
+    return (
+      <div className={ this.props.className }>
+        { shouldShowArrow ? <div className={ arrowPlacement }></div> : null }
+        <div className='rs-popover-content'>
+          {this.props.children}
         </div>
-      );
-    } else {
-      return (
-        <div className={this.props.className}>
-          <div className='rs-popover-content'>
-            {this.props.children}
-          </div>
-        </div>
-      );
-    }
+      </div>
+    );
   }
 }
 
@@ -49,9 +34,7 @@ PopoverOverlay.defaultProps = {
 
 PopoverOverlay.propTypes = {
   children: React.PropTypes.node.isRequired,
-  placement: React.PropTypes.oneOf([
-    'right', 'bottom-right', 'left', 'bottom-left', 'center'
-  ])
+  placement: React.PropTypes.oneOf(Object.keys(ARROW_POSITIONS))
 };
 
 export default PopoverOverlay;

--- a/src/ProcessingIndicator.jsx
+++ b/src/ProcessingIndicator.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import classNames from 'classnames';
 
 class ProcessingIndicator extends React.Component {
-
   render() {
     let classes;
 
@@ -12,7 +11,7 @@ class ProcessingIndicator extends React.Component {
     );
 
     return (
-      <i className={classes}></i>
+      <i className={ classes }></i>
     );
   }
 }

--- a/src/ProgressBar.jsx
+++ b/src/ProgressBar.jsx
@@ -22,33 +22,23 @@ const TYPE_CLASSES = {
 };
 
 class ProgressBar extends React.Component {
-
-  _getSizeClass() {
-     return classNames(
+  render() {
+    const sizeClass = classNames(
       'rs-progress',
       SIZE_CLASSES[this.props.size]
     );
-  }
-
-  _getStatusClass() {
-    return classNames(
+    const statusClass = classNames(
       'rs-bar',
       STATUS_CLASSES[this.props.status],
       TYPE_CLASSES[this.props.type]
     );
-  }
-
-  render() {
-    let style, width;
-
-    width = this.props.progress + '%';
-    style = { 'width': width };
+    const style = { 'width': `${ this.props.progress }%` };
 
     return (
-      <div className={this._getSizeClass()}>
+      <div className={ sizeClass }>
         <div className='rs-progress-inner'>
-          <div className='rs-segment' style={style}>
-            <div className={this._getStatusClass()}></div>
+          <div className='rs-segment' style={ style }>
+            <div className={ statusClass }></div>
           </div>
         </div>
       </div>
@@ -58,9 +48,9 @@ class ProgressBar extends React.Component {
 
 ProgressBar.propTypes = {
   progress: React.PropTypes.number,
-  status: React.PropTypes.string,
-  type: React.PropTypes.string,
-  size: React.PropTypes.string
+  status: React.PropTypes.oneOf(Object.keys(STATUS_CLASSES)),
+  type: React.PropTypes.oneOf(Object.keys(TYPE_CLASSES)),
+  size: React.PropTypes.oneOf(Object.keys(SIZE_CLASSES)),
 };
 
 ProgressBar.defaultProps = {

--- a/src/StatusIndicator.jsx
+++ b/src/StatusIndicator.jsx
@@ -10,25 +10,22 @@ const STATUS_INDICATOR = {
 };
 
 class StatusIndicator extends React.Component {
-
   render() {
-    let classes;
-
-    classes = classNames(
+    const classes = classNames(
       this.props.className,
       STATUS_INDICATOR[this.props.status],
       { 'rs-hidden': this.props.hidden }
     );
     return (
-      <span {...this.props} className={classes}>
-        {this.props.children}
+      <span { ...this.props } className={ classes }>
+        { this.props.children }
       </span>
     );
   }
 }
 
 StatusIndicator.propTypes = {
-  status: React.PropTypes.oneOf(['ok', 'error', 'processing', 'warning', 'disabled']),
+  status: React.PropTypes.oneOf(Object.keys(STATUS_INDICATOR)),
   hidden: React.PropTypes.bool
 };
 

--- a/src/TooltipTrigger.jsx
+++ b/src/TooltipTrigger.jsx
@@ -2,10 +2,50 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import Tether from 'tether';
 
-class TooltipTrigger extends React.Component {
+const PLACEMENT = {
+  'left': {
+    attachment: 'middle right',
+    targetAttachment: 'middle left'
+  },
+  'bottom-left': {
+    attachment: 'top right',
+    targetAttachment: 'bottom left'
+  },
+  'top-left': {
+    attachment: 'bottom right',
+    targetAttachment: 'top left'
+  },
+  'top': {
+    attachment: 'bottom middle',
+    targetAttachment: 'top middle'
+  },
+  'bottom': {
+    attachment: 'top middle',
+    targetAttachment: 'bottom middle'
+  },
+  'right': {
+    attachment: 'middle left',
+    targetAttachment: 'middle right'
+  },
+  'top-right': {
+    attachment: 'bottom left',
+    targetAttachment: 'top right'
+  },
+  'bottom-right': {
+    attachment: 'top left',
+    targetAttachment: 'bottom right'
+  }
+};
 
+class TooltipTrigger extends React.Component {
   constructor(props) {
     super(props);
+
+    this._mouseEnteringTooltip = this._mouseEnteringTooltip.bind(this);
+    this._mouseLeavingTooltip = this._mouseLeavingTooltip.bind(this);
+    this._showTooltipOnInterval = this._showTooltipOnInterval.bind(this);
+    this._hideTooltipOnInterval = this._hideTooltipOnInterval.bind(this);
+
     this.state = {
       isTooltipOpen: false,
       isMouseInTooltip: false
@@ -41,11 +81,7 @@ class TooltipTrigger extends React.Component {
   }
 
   _updateTooltipVisibility() {
-    if (this._shouldShowTooltip()) {
-      this._showTooltip();
-    } else {
-      this._hideTooltip();
-    }
+    this._shouldShowTooltip() ? this._showTooltip() : this._hideTooltip();
   }
 
   _hideTooltip() {
@@ -67,9 +103,9 @@ class TooltipTrigger extends React.Component {
     // render the subtree into a container so the popover will receive the context from the parent
     this._tooltipNode = ReactDOM.unstable_renderSubtreeIntoContainer(this, (
       <div className='rs-tooltip-inner'
-        onMouseOver={this._mouseEnteringTooltip.bind(this)}
-        onMouseLeave={this._mouseLeavingTooltip.bind(this)}>
-        {this.props.content}
+        onMouseOver={ this._mouseEnteringTooltip }
+        onMouseLeave={ this._mouseLeavingTooltip }>
+        { this.props.content }
       </div>
     ), this._containerDiv);
 
@@ -83,59 +119,7 @@ class TooltipTrigger extends React.Component {
   }
 
   _getTetherConfig() {
-    let tetherConfig;
-
-    switch (this.props.placement) {
-      case 'left':
-        tetherConfig = {
-          attachment: 'middle right',
-          targetAttachment: 'middle left'
-        };
-        break;
-      case 'bottom-left':
-        tetherConfig = {
-          attachment: 'top right',
-          targetAttachment: 'bottom left'
-        };
-        break;
-      case 'top-left':
-        tetherConfig = {
-          attachment: 'bottom right',
-          targetAttachment: 'top left'
-        };
-        break;
-      case 'top':
-        tetherConfig = {
-          attachment: 'bottom middle',
-          targetAttachment: 'top middle'
-        };
-        break;
-      case 'bottom':
-        tetherConfig = {
-          attachment: 'top middle',
-          targetAttachment: 'bottom middle'
-        };
-        break;
-      case 'right':
-        tetherConfig = {
-          attachment: 'middle left',
-          targetAttachment: 'middle right'
-        };
-        break;
-      case 'top-right':
-        tetherConfig = {
-          attachment: 'bottom left',
-          targetAttachment: 'top right'
-        };
-        break;
-      case 'bottom-right':
-      default:
-        tetherConfig = {
-          attachment: 'top left',
-          targetAttachment: 'bottom right'
-        };
-      break;
-    }
+    let tetherConfig = PLACEMENT[this.props.placement] || PLACEMENT['bottom-right'];
 
     tetherConfig.targetModifier = 'visible';
     tetherConfig.element = ReactDOM.findDOMNode(this._containerDiv);
@@ -148,15 +132,11 @@ class TooltipTrigger extends React.Component {
   }
 
   render() {
-    let triggerProps, showTooltipfunc, hideTooltipFunc;
-
-    showTooltipfunc = this._showTooltipOnInterval.bind(this);
-    hideTooltipFunc = this._hideTooltipOnInterval.bind(this);
-    triggerProps = {
-      onMouseOver: showTooltipfunc,
-      onMouseLeave: hideTooltipFunc,
-      onFocus: showTooltipfunc,
-      onBlur: hideTooltipFunc,
+    const triggerProps = {
+      onMouseOver: this._showTooltipOnInterval,
+      onMouseLeave: this._hideTooltipOnInterval,
+      onFocus: this._showTooltipOnInterval,
+      onBlur: this._hideTooltipOnInterval,
       ref: 'trigger'
     };
 
@@ -167,14 +147,14 @@ class TooltipTrigger extends React.Component {
     if (this._hideTimer) {
       clearInterval(this._hideTimer);
     }
-    this._showTimer = setTimeout(() => { this.setState({isTooltipOpen: true}); }, 200);
+    this._showTimer = setTimeout(() => { this.setState({ isTooltipOpen: true }); }, 200);
   }
 
   _hideTooltipOnInterval() {
     if (this._showTimer) {
       clearInterval(this._showTimer);
     }
-    this._hideTimer = setTimeout(() => { this.setState({isTooltipOpen: false}); }, 200);
+    this._hideTimer = setTimeout(() => { this.setState({ isTooltipOpen: false }); }, 200);
   }
 
   _shouldShowTooltip() {
@@ -186,29 +166,20 @@ class TooltipTrigger extends React.Component {
   }
 
   _mouseLeavingTooltip() {
-    this._hideOnLeavingTooltipTimer = setTimeout(() => { this.setState({isMouseInTooltip: false}); }, 250);
+    this._hideOnLeavingTooltipTimer = setTimeout(() => { this.setState({ isMouseInTooltip: false }); }, 250);
   }
 
   _mouseEnteringTooltip() {
     if (this._hideOnLeavingTooltipTimer) {
       clearInterval(this._hideOnLeavingTooltipTimer);
     }
-    this.setState({isMouseInTooltip: true});
+    this.setState({ isMouseInTooltip: true });
   }
 }
 
 TooltipTrigger.propTypes = {
   content: React.PropTypes.node.isRequired,
-  placement: React.PropTypes.oneOf([
-    'right',
-    'bottom-right',
-    'top-right',
-    'top',
-    'left',
-    'bottom-left',
-    'top-left',
-    'bottom'
-  ])
+  placement: React.PropTypes.oneOf(Object.keys(PLACEMENT))
 };
 
 TooltipTrigger.defaultProps = {


### PR DESCRIPTION
Including -

- reduce duplication within components by evaluating conditional display of subcomponents inline
- ternary over if/else if logic flow is simple enough
- prefer arrow function over ```function ()```
- classname module utilization - if module is being used, use consistently for all classes on an element
- curly bracket spacing (can be a lint rule, mebbe in another PR) - spaces after opening brace and before closing brace - ```{ this.is.good }``` vs ```{this.is.ew}```
- proptype declaration - use Object.keys(WHAT_NOT) whenever possible to reduce duplication while retaining concise reference to accetable values
- var declaration via let vs const - const whenever possible, using let when something will be reassigned or edited
- binding functions in constructor - this should be done to avoid binding a function more than once

If you feel that this is too many changes please let me know and I can split each point into a PR of it's own for ease. It's really all pretty straightforward, though.