### PR TITLE
feat(FormField): Allow inline validation

### DIFF
--- a/demo/DemoForm.jsx
+++ b/demo/DemoForm.jsx
@@ -21,6 +21,12 @@ class DemoForm extends React.Component {
                <option>Option Two</option>
              </select>
           </FormField>
+          <FormField label="Inline Error" error="This input is not valid" inlineValidation>
+            <input type="text" />
+          </FormField>
+          <FormField label="Inline Success" success inlineValidation>
+            <input type="text" />
+          </FormField>
         </Form>
       </DetailsSection>
     );

--- a/src/FormField.jsx
+++ b/src/FormField.jsx
@@ -18,7 +18,7 @@ const FormField = (props) => {
       <div className="rs-controls">
         { props.children }
         <FormFieldHelp help={ props.help } />
-        <FormFieldValidationBlock value={ props.error || props.success } />
+        <FormFieldValidationBlock value={ props.error || props.success } inline={ props.inlineValidation } />
       </div>
     </div>
   );
@@ -26,7 +26,8 @@ const FormField = (props) => {
 
 FormField.propTypes = {
   error: React.PropTypes.string,
-  success: React.PropTypes.string,
+  success: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.bool]),
+  inlineValidation: React.PropTypes.bool,
   help: React.PropTypes.node,
   label: React.PropTypes.node.isRequired,
   children: React.PropTypes.node.isRequired

--- a/src/FormFieldValidationBlock.jsx
+++ b/src/FormFieldValidationBlock.jsx
@@ -1,15 +1,26 @@
 import React from 'react';
+import classnames from 'classnames';
 
 const FormFieldValidationBlock = (props) => {
+  const classes = classnames(
+    {
+      'rs-validation-block': !props.inline,
+      'rs-validation-inline': props.inline
+    }
+  );
+  const style = {
+    'vertical-align': 'text-top'
+  };
   return props.value ? (
-    <span className="rs-validation-block">
+    <div className={ classes } style={ style }>
       <i className="rs-validation-indicator"></i> { props.value }
-    </span>
+    </div>
   ) : <noscript />;
 };
 
 FormFieldValidationBlock.propTypes = {
-  value: React.PropTypes.node
+  value: React.PropTypes.node,
+  inline: React.PropTypes.bool
 };
 
 export default FormFieldValidationBlock;

--- a/test/FormFieldSpec.jsx
+++ b/test/FormFieldSpec.jsx
@@ -35,7 +35,21 @@ describe('FormField', () => {
     });
   });
 
-  describe('when there is a fixed error', () => {
+  describe('when there is inline validation', () => {
+    beforeEach(() => {
+      renderWithProps({ inlineValidation: true });
+      formField = renderer.getRenderOutput();
+    });
+
+    it('passes the inline validation bool to the validation block', () => {
+      const controls = formField.props.children[1];
+      const validationBlock = controls.props.children[2];
+
+      expect(validationBlock.props.inline).toBe(true);
+    });
+  });
+
+  describe('when there is a success message', () => {
     beforeEach(() => {
       renderWithProps({ success: 'Test success message' });
       formField = renderer.getRenderOutput();
@@ -50,6 +64,17 @@ describe('FormField', () => {
       const validationBlock = controls.props.children[2];
 
       expect(validationBlock.props.value).toBe('Test success message');
+    });
+  });
+
+  describe('when success is true', () => {
+    beforeEach(() => {
+      renderWithProps({ success: true });
+      formField = renderer.getRenderOutput();
+    });
+
+    it('adds the success class', () => {
+      expect(formField.props.className).toEqual('rs-control-group success');
     });
   });
 

--- a/test/FormFieldValidationBlockSpec.jsx
+++ b/test/FormFieldValidationBlockSpec.jsx
@@ -25,10 +25,31 @@ describe('FormFieldValidationBlock', () => {
     expect(formFieldValidationBlock.props.children[2]).toEqual('test message');
   });
 
+  it('has the rs-validation-block class when not inline', () => {
+    renderer.render(<FormFieldValidationBlock value="test message" />);
+    const formFieldValidationBlock = renderer.getRenderOutput();
+
+    expect(formFieldValidationBlock.props.className).toEqual('rs-validation-block');
+  });
+
+  it('has the rs-validation-inline class when inline', () => {
+    renderer.render(<FormFieldValidationBlock value="test message" inline />);
+    const formFieldValidationBlock = renderer.getRenderOutput();
+
+    expect(formFieldValidationBlock.props.className).toEqual('rs-validation-inline');
+  });
+
   it('returns null if no field is passed to it', () => {
     renderer.render(<FormFieldValidationBlock />);
     const formFieldValidationBlock = renderer.getRenderOutput();
 
     expect(formFieldValidationBlock.type).toBe('noscript');
+  });
+
+  it('has a text-top vertical align style', () => {
+    renderer.render(<FormFieldValidationBlock value="test message" />);
+    const formFieldValidationBlock = renderer.getRenderOutput();
+
+    expect(formFieldValidationBlock.props.style['vertical-align']).toEqual('text-top');
   });
 });


### PR DESCRIPTION
Allow users to pass an inlineValidation prop into a FormField component to make the validation be inline with the field contents.  Also allow the success prop to be a boolean or string, so that an empty message can be shown with the green check mark.

![image](https://cloud.githubusercontent.com/assets/955442/16886243/03e07140-4aa1-11e6-8acc-d3fe4de00bf9.png)
