### PR TITLE
fix(List Table): Fix incorrect direction and overlay status proptype declarations

### DIFF
--- a/demo/DemoListTableSection.jsx
+++ b/demo/DemoListTableSection.jsx
@@ -27,7 +27,7 @@ const DemoListTableHeader = ({ onSort, sortColumn, direction }) => (
 DemoListTableHeader.propTypes = {
   onSort: React.PropTypes.func,
   sortColumn: React.PropTypes.string,
-  direction: React.PropTypes.oneOf(Object.keys(SortDirection))
+  direction: React.PropTypes.oneOf(Object.values(SortDirection))
 };
 
 const DemoListTableRow = ({ instance }) => (

--- a/src/EmbeddedListTable.jsx
+++ b/src/EmbeddedListTable.jsx
@@ -52,7 +52,7 @@ EmbeddedListTable.propTypes = {
   emptyOverlay: PropTypes.node,
   errorOverlay: PropTypes.node,
   loadingOverlay: PropTypes.node,
-  overlayStatus: PropTypes.oneOf(Object.keys(OverlayStatus)),
+  overlayStatus: PropTypes.oneOf(Object.values(OverlayStatus)),
   size: PropTypes.oneOf(Object.keys(SIZE_CLASSES))
 };
 

--- a/src/ListTable.jsx
+++ b/src/ListTable.jsx
@@ -39,7 +39,7 @@ ListTable.propTypes = {
   emptyOverlay: PropTypes.node,
   errorOverlay: PropTypes.node,
   loadingOverlay: PropTypes.node,
-  overlayStatus: PropTypes.oneOf(Object.keys(OverlayStatus))
+  overlayStatus: PropTypes.oneOf(Object.values(OverlayStatus))
 };
 
 export default ListTable;

--- a/src/ListTableHeader.jsx
+++ b/src/ListTableHeader.jsx
@@ -40,7 +40,7 @@ ListTableHeader.defaultProps = {
 ListTableHeader.propTypes = {
   onSort: PropTypes.func,
   sortColumn: PropTypes.string,
-  direction: PropTypes.oneOf(Object.keys(SortDirection))
+  direction: PropTypes.oneOf(Object.values(SortDirection))
 };
 
 export default ListTableHeader;

--- a/src/ListTableOverlaySelector.jsx
+++ b/src/ListTableOverlaySelector.jsx
@@ -25,7 +25,7 @@ ListTableOverlaySelector.propTypes = {
   emptyOverlay: PropTypes.node,
   errorOverlay: PropTypes.node,
   loadingOverlay: PropTypes.node,
-  overlayStatus: PropTypes.oneOf(Object.keys(OverlayStatus))
+  overlayStatus: PropTypes.oneOf(Object.values(OverlayStatus))
 };
 
 export default ListTableOverlaySelector;

--- a/src/TextColumnHeader.jsx
+++ b/src/TextColumnHeader.jsx
@@ -58,7 +58,7 @@ TextColumnHeader.propTypes = {
   label: PropTypes.string.isRequired,
   sortable: PropTypes.bool.isRequired,
   onSort: PropTypes.func.isRequired,
-  direction: PropTypes.oneOf(Object.keys(SortDirection))
+  direction: PropTypes.oneOf(Object.values(SortDirection))
 };
 
 export default TextColumnHeader;


### PR DESCRIPTION
SortDirection and OverlayStatus are mappings of key names (SortDirection.ASCENDING, frex) to values ('asc') so that a developer can use the key names to pass the values. Therefore, the PropTypes declaration should be validating on the value that would be passed, not the key name.