### PR TITLE
fix(automation): add tar zip step to release script

### DIFF
--- a/scripts/publish_new_release.py
+++ b/scripts/publish_new_release.py
@@ -10,7 +10,8 @@ RELEASES_ENDPOINT = "https://api.github.com/repos/rackerlabs/canon-react/release
 # prepare for uploading the new release
 os.system("git checkout master")
 os.system("git pull")
-os.system("sudo scripts/cibuild")
+os.system("sh scripts/cibuild")
+os.system("tar -czvf canon-react.tar.gz canon-react.min.js")
 
 # get the version number
 node_file = open(os.path.dirname(__file__) + '/../package.json', "r")


### PR DESCRIPTION
This resolves a few bugs with the automation script that were due to the idiosyncratic setup I had locally. We don't need `sudo` to run the `cibuild` script, and since tar-ing the minified JS doesn't happen by default, that needs to happen within this script.