### PR TITLE
feat(ListTableBody): make row key accessible to the row itself

### DIFF
--- a/src/ListTableBody.jsx
+++ b/src/ListTableBody.jsx
@@ -20,9 +20,11 @@ class ListTableBody extends React.Component {
   }
 
   _cloneRow(instance, index, array) {
+    const key = this.props.keyGenerator(instance, index, array);
     return React.cloneElement(this.props.children, {
       instance: instance,
-      key: this.props.keyGenerator(instance, index, array)
+      key: key,
+      rowKey: key
     });
   }
 }

--- a/src/ListTableRow.jsx
+++ b/src/ListTableRow.jsx
@@ -13,7 +13,8 @@ const cloneChildren = (props) => {
 };
 
 ListTableRow.propTypes = {
-  instance: React.PropTypes.object
+  instance: React.PropTypes.object,
+  rowKey: React.PropTypes.string
 };
 
 export default ListTableRow;

--- a/test/ListTableBodySpec.jsx
+++ b/test/ListTableBodySpec.jsx
@@ -36,6 +36,11 @@ describe('ListTableBody', () => {
     expect(listTableBody.find(DummyRow).at(1).key()).toBe('2');
   });
 
+  it('passes the id of the objects in the collection to the children in a prop they can access', () => {
+    expect(listTableBody.find(DummyRow).at(0).prop('rowKey')).toBe(1);
+    expect(listTableBody.find(DummyRow).at(1).prop('rowKey')).toBe(2);
+  });
+
   it('generates the key via the passed keyGenerator', () => {
     listTableBody = shallow(
       <ListTableBody collection={ collection } keyGenerator={ (instance) => (instance.name) }>


### PR DESCRIPTION
Imagine you're displaying the contents of a dictionary in a table. The table expects its data to be described as an array. This makes sense, but it's a bit inconvenient. For example, let's say you want the items in the dictionary to be displayed sorted by key. You would do something like this:
```
const sortedKeys = data.keys().sort();
const sortedObjects = sortedKeys.map((key) => data[key]);
return <ListTableBody collection={sortedObjects} keyGenerator={(instance, index) => sortedKeys[index])} />
```
And you have the data, piece of cake. But there's a problem: that resulting array doesn't have the key anymore!

No problem, you can put it back in:
```
const sortedKeys = data.keys().sort();
const sortedObjects = sortedKeys.map((key) => ({ dataId: key, data: data[key] }));
return <ListTableBody collection={sortedObjects} keyGenerator={(instance, index) => sortedKeys[index])} />
```
This is all well and good until you actually need to retrieve data within the component:
```
const componentValue = this.props.instance.data.someKey...
```
Kind of clumsy. The worst thing about it is, the row is already receiving that key as a prop! But child components don't have access to their own `key` prop, so it can't get it.

My proposal is to add a rowKey property to the rendered row, so that the row can tell what its key is. That should make it much easier to use tables for dictionaries.