### PR TITLE
Add multistep progress components

### DIFF
--- a/demo/DemoMultiStepProgressSection.jsx
+++ b/demo/DemoMultiStepProgressSection.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import ProgressBarContainer from './ProgressBarContainer';
+import ProgressSegment from './ProgressSegment';
+
+class DemoMultiStepProgressSection extends React.Component {
+  render() {
+    return (
+      <div className='rs-detail-section'>
+        <div className='rs-detail-section-header'>
+          <h2>Multi Step Progress Bars</h2>
+        </div>
+        <div className='rs-detail-section-body'>
+          <ProgressBarContainer size='large'>
+            <ProgressSegment width={25} type='solid' status='warning'>1. Step One</ProgressSegment>
+            <ProgressSegment width={25} type='striped' status='warning'>2. Step Two</ProgressSegment>
+            <ProgressSegment width={25}>3. Step Three</ProgressSegment>
+            <ProgressSegment width={25}>4. Step Four</ProgressSegment>
+          </ProgressBarContainer>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default DemoMultiStepProgressSection;

--- a/demo/DemoView.jsx
+++ b/demo/DemoView.jsx
@@ -14,6 +14,7 @@ import DemoDetailSectionCollapsible from './DemoDetailSectionCollapsible';
 import DemoDetailSectionDefaultCollapsed from './DemoDetailSectionDefaultCollapsed';
 import DemoDetailSectionCollapsibleLoading from './DemoDetailSectionCollapsibleLoading';
 import DemoListTableSection from './DemoListTableSection';
+import DemoMultiStepProgressSection from './DemoMultiStepProgressSection';
 
 class DemoView extends React.Component {
   render() {
@@ -27,6 +28,7 @@ class DemoView extends React.Component {
         <DemoDetailSectionCollapsibleLoading />
         <DemoForm />
         <DemoProgressBarSection />
+        <DemoMultiStepProgressSection />
         <DemoStatusIndicatorSection />
         <DemoPopoverSection />
         <DemoTooltipSection />

--- a/src/ProgressBar.jsx
+++ b/src/ProgressBar.jsx
@@ -1,47 +1,15 @@
 import React from 'react';
-import classNames from 'classnames';
-
-const SIZE_CLASSES = {
-  'xsmall': 'rs-progress-xsmall',
-  'small': 'rs-progress-small',
-  'medium': 'rs-progress-medium',
-  'large': 'rs-progress-large',
-  'xlarge': 'rs-progress-xlarge'
-};
-
-const STATUS_CLASSES = {
-  'ok': 'rs-status-ok',
-  'error': 'rs-status-error',
-  'warning': 'rs-status-warning',
-  'info': 'rs-status-info'
-};
-
-const TYPE_CLASSES = {
-  'solid': 'rs-bar-solid',
-  'striped': 'rs-bar-striped'
-};
+import ProgressBarContainer, { SIZE_CLASSES } from './ProgressBarContainer';
+import ProgressSegment, { STATUS_CLASSES, TYPE_CLASSES } from './ProgressSegment';
 
 class ProgressBar extends React.Component {
   render() {
-    const sizeClass = classNames(
-      'rs-progress',
-      SIZE_CLASSES[this.props.size]
-    );
-    const statusClass = classNames(
-      'rs-bar',
-      STATUS_CLASSES[this.props.status],
-      TYPE_CLASSES[this.props.type]
-    );
-    const style = { 'width': `${ this.props.progress }%` };
+    const { size, type, status, progress } = this.props;
 
     return (
-      <div className={ sizeClass }>
-        <div className='rs-progress-inner'>
-          <div className='rs-segment' style={ style }>
-            <div className={ statusClass }></div>
-          </div>
-        </div>
-      </div>
+      <ProgressBarContainer { ...{ size } }>
+        <ProgressSegment { ...{ type, status } } width={ progress } />
+      </ProgressBarContainer>
     );
   }
 }
@@ -50,7 +18,7 @@ ProgressBar.propTypes = {
   progress: React.PropTypes.number,
   status: React.PropTypes.oneOf(Object.keys(STATUS_CLASSES)),
   type: React.PropTypes.oneOf(Object.keys(TYPE_CLASSES)),
-  size: React.PropTypes.oneOf(Object.keys(SIZE_CLASSES)),
+  size: React.PropTypes.oneOf(Object.keys(SIZE_CLASSES))
 };
 
 ProgressBar.defaultProps = {

--- a/src/ProgressBarContainer.jsx
+++ b/src/ProgressBarContainer.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import classNames from 'classnames';
+
+export const SIZE_CLASSES = {
+  'xsmall': 'rs-progress-xsmall',
+  'small': 'rs-progress-small',
+  'medium': 'rs-progress-medium',
+  'large': 'rs-progress-large',
+  'xlarge': 'rs-progress-xlarge'
+};
+
+class ProgressBarContainer extends React.Component {
+  render() {
+    const sizeClass = classNames(
+      'rs-progress',
+      SIZE_CLASSES[this.props.size]
+    );
+
+    return (
+      <div className={ sizeClass }>
+        <div className="rs-progress-inner">
+          {this.props.children}
+        </div>
+      </div>
+    );
+  }
+}
+
+ProgressBarContainer.propTypes = {
+  size: React.PropTypes.oneOf(Object.keys(SIZE_CLASSES))
+};
+
+export default ProgressBarContainer;

--- a/src/ProgressSegment.jsx
+++ b/src/ProgressSegment.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import classNames from 'classnames';
+
+export const STATUS_CLASSES = {
+  'ok': 'rs-status-ok',
+  'error': 'rs-status-error',
+  'warning': 'rs-status-warning',
+  'info': 'rs-status-info',
+  'none': ''
+};
+
+export const TYPE_CLASSES = {
+  'solid': 'rs-bar-solid',
+  'striped': 'rs-bar-striped',
+  'empty': ''
+};
+
+class ProgressSegment extends React.Component {
+  render() {
+    let caption;
+    if (this.props.children) {
+      caption = (
+        <div className="rs-caption">
+          { this.props.children }
+        </div>
+      );
+    }
+
+    const statusClass = classNames(
+      'rs-bar',
+      STATUS_CLASSES[this.props.status],
+      TYPE_CLASSES[this.props.type]
+    );
+
+    const style = { 'width': `${ this.props.width }%` };
+
+    return (
+      <div className='rs-segment' { ...{ style } }>
+        <div className={ statusClass }></div>
+        { caption }
+      </div>
+    );
+  }
+}
+
+ProgressSegment.propTypes = {
+  width: React.PropTypes.number.isRequired,
+  status: React.PropTypes.oneOf(Object.keys(STATUS_CLASSES)),
+  type: React.PropTypes.oneOf(Object.keys(TYPE_CLASSES))
+};
+
+ProgressSegment.defaultProps = {
+  status: 'none',
+  type: 'empty'
+};
+
+export default ProgressSegment;

--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,8 @@ import PopoverFooter from './PopoverFooter';
 import PopoverOverlay from './PopoverOverlay';
 import ProcessingIndicator from './ProcessingIndicator';
 import ProgressBar from './ProgressBar';
+import ProgressBarContainer from './ProgressBarContainer';
+import ProgressSegment from './ProgressSegment';
 import SortDirection from './SortDirection';
 import StatusColumnHeader from './StatusColumnHeader';
 import StatusIndicator from './StatusIndicator';
@@ -83,6 +85,8 @@ export {
   PopoverOverlay,
   ProcessingIndicator,
   ProgressBar,
+  ProgressBarContainer,
+  ProgressSegment,
   SortDirection,
   StatusColumnHeader,
   StatusIndicator,

--- a/test/ProgressBarContainerSpec.jsx
+++ b/test/ProgressBarContainerSpec.jsx
@@ -1,0 +1,66 @@
+import ProgressBarContainer from '../transpiled/ProgressBarContainer';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import TestUtils from 'react-addons-test-utils';
+
+describe('ProgressBarContainer', () => {
+  let progressBarContainer;
+
+  beforeEach(() => {
+    progressBarContainer = TestUtils.renderIntoDocument(
+      <ProgressBarContainer/>
+    );
+  });
+
+  afterEach(() => {
+    ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(progressBarContainer).parentNode);
+  });
+
+  it('renders the progress container', () => {
+    expect(TestUtils.findRenderedDOMComponentWithClass(progressBarContainer, 'rs-progress')).not.toBeNull();
+  });
+
+  it('renders the inner progress container', () => {
+    expect(TestUtils.findRenderedDOMComponentWithClass(progressBarContainer, 'rs-progress-inner')).not.toBeNull();
+  });
+
+  describe('size', () => {
+    const renderWithSize = (size) => {
+      progressBarContainer = TestUtils.renderIntoDocument(<ProgressBarContainer size={size} />);
+    };
+
+    it('defaults to no size', () => {
+      expect(ReactDOM.findDOMNode(progressBarContainer).className).toBe('rs-progress');
+    });
+
+    it('xsmall', () => {
+      renderWithSize('xsmall');
+
+      expect(ReactDOM.findDOMNode(progressBarContainer)).toHaveClass('rs-progress-xsmall');
+    });
+
+    it('small', () => {
+      renderWithSize('small');
+
+      expect(ReactDOM.findDOMNode(progressBarContainer)).toHaveClass('rs-progress-small');
+    });
+
+    it('medium', () => {
+      renderWithSize('medium');
+
+      expect(ReactDOM.findDOMNode(progressBarContainer)).toHaveClass('rs-progress-medium');
+    });
+
+    it('large', () => {
+      renderWithSize('large');
+
+      expect(ReactDOM.findDOMNode(progressBarContainer)).toHaveClass('rs-progress-large');
+    });
+
+    it('xlarge', () => {
+      renderWithSize('xlarge');
+
+      expect(ReactDOM.findDOMNode(progressBarContainer)).toHaveClass('rs-progress-xlarge');
+    });
+  });
+});

--- a/test/ProgressSegmentSpec.jsx
+++ b/test/ProgressSegmentSpec.jsx
@@ -1,0 +1,115 @@
+import ProgressSegment from '../transpiled/ProgressSegment';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import TestUtils from 'react-addons-test-utils';
+
+describe('ProgressSegment', () => {
+  let progressSegment;
+
+  beforeEach(() => {
+    progressSegment = TestUtils.renderIntoDocument(
+      <ProgressSegment/>
+    );
+  });
+
+  afterEach(() => {
+    ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(progressSegment).parentNode);
+  });
+
+  it('renders the segment with the given width', () => {
+    let progressSegment;
+
+    progressSegment = TestUtils.renderIntoDocument(
+      <ProgressSegment width={50} />
+    );
+    progressSegment = TestUtils.findRenderedDOMComponentWithClass(progressSegment, 'rs-segment');
+
+    expect(progressSegment.props.style).toEqual({ 'width': '50%' });
+  });
+
+  it('does not render a caption if there are no children', () => {
+    progressSegment = TestUtils.renderIntoDocument(
+      <ProgressSegment width={100} />
+    );
+    const caption = TestUtils.scryRenderedDOMComponentsWithClass(progressSegment, 'rs-caption');
+
+    expect(caption.length).toBe(0);
+  });
+
+  it('renders a caption of there are children', () => {
+    progressSegment = TestUtils.renderIntoDocument(
+      <ProgressSegment width={100}>
+        caption
+      </ProgressSegment>
+    );
+    const caption = TestUtils.findRenderedDOMComponentWithClass(progressSegment, 'rs-caption');
+
+    expect(ReactDOM.findDOMNode(caption).textContent).toBe('caption');
+  });
+
+  describe('status bar', () => {
+    let statusBar;
+
+    const renderWithStatus = (status) => {
+      progressSegment = TestUtils.renderIntoDocument(<ProgressSegment status={status} />);
+      statusBar = TestUtils.findRenderedDOMComponentWithClass(progressSegment, 'rs-bar');
+    };
+
+    it('defaults to empty status', () => {
+      statusBar = TestUtils.findRenderedDOMComponentWithClass(progressSegment, 'rs-bar');
+
+      expect(ReactDOM.findDOMNode(statusBar)).toHaveClass('rs-bar');
+    });
+
+    it('renders with an ok status', () => {
+      renderWithStatus('ok');
+
+      expect(ReactDOM.findDOMNode(statusBar)).toHaveClass('rs-status-ok');
+    });
+
+    it('renders with an error status', () => {
+      renderWithStatus('error');
+
+      expect(ReactDOM.findDOMNode(statusBar)).toHaveClass('rs-status-error');
+    });
+
+    it('renders with a warning status', () => {
+      renderWithStatus('warning');
+
+      expect(ReactDOM.findDOMNode(statusBar)).toHaveClass('rs-status-warning');
+    });
+
+    it('renders with an info sttaus', () => {
+      renderWithStatus('info');
+
+      expect(ReactDOM.findDOMNode(statusBar)).toHaveClass('rs-status-info');
+    });
+  });
+
+  describe('type', () => {
+    let statusBar;
+
+    const renderWithType = (type) => {
+      progressSegment = TestUtils.renderIntoDocument(<ProgressSegment type={type} />);
+      statusBar = TestUtils.findRenderedDOMComponentWithClass(progressSegment, 'rs-bar');
+    };
+
+    it('defaults to empty', () => {
+      statusBar = TestUtils.findRenderedDOMComponentWithClass(progressSegment, 'rs-bar');
+
+      expect(ReactDOM.findDOMNode(statusBar)).toHaveClass('rs-bar');
+    });
+
+    it('renders with a solid type', () => {
+      renderWithType('solid');
+
+      expect(ReactDOM.findDOMNode(statusBar)).toHaveClass('rs-bar-solid');
+    });
+
+    it('renders with a striped type', () => {
+      renderWithType('striped');
+
+      expect(ReactDOM.findDOMNode(statusBar)).toHaveClass('rs-bar-striped');
+    });
+  });
+});


### PR DESCRIPTION
I extracted some of the common functionality of the existing progress bar and multi step progress bar components into a ProgressSegment and ProgressBarContainer components.  The normal ProgressBar now uses these components and works the same, while multistep progress bars can be created by putting multiple segments into a container.
![image](https://cloud.githubusercontent.com/assets/955442/19204056/b19b20ca-8ca8-11e6-9f1c-dd38daeeb4dc.png)
