### PR TITLE
Add optional prop to display additional content on the FormPopover footer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ test-results.xml
 npm-debug.log
 demo/bundle.js
 _book/*
+documentation/bundle.js

--- a/demo/DemoPopoverSection.jsx
+++ b/demo/DemoPopoverSection.jsx
@@ -5,6 +5,8 @@ import Button from './Button';
 import DemoFormPopover from './DemoFormPopover';
 import DemoPopover from './DemoPopover';
 import DetailsSection from './DetailsSection';
+import StatusIndicator from './StatusIndicator';
+import TooltipTrigger from './TooltipTrigger';
 
 class DemoPopoverSection extends React.Component {
   constructor(props) {
@@ -97,6 +99,32 @@ class DemoPopoverSection extends React.Component {
                   onSubmit={ () => { this.setState({ formPopoverSubmitting: true }) } }
                   onRequestClose={ () => { this.setState({ formPopoverOpen: false }) } }
                   additionalControls={ [ <Button onClick={ (e) => { e.preventDefault(); } } canonStyle="secondary">Opt. Addl Controls</Button> ] } />
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <Button
+                  id="form-popover-with-additional-footer-content-button"
+                  onClick={ () => this.setState({
+                    formPopoverWithAdditionalFooterContentOpen: true,
+                    formPopoverWithAdditionalFooterContentSubmitting: false
+                  }) }>
+                  Submittable with additional footer content
+                </Button>
+                <DemoFormPopover
+                  placement="right"
+                  processing={ this.state.formPopoverWithAdditionalFooterContentSubmitting }
+                  target={ () => document.getElementById('form-popover-with-additional-footer-content-button') }
+                  isOpen={ !!this.state.formPopoverWithAdditionalFooterContentOpen }
+                  onSubmit={ () => this.setState({ formPopoverWithAdditionalFooterContentSubmitting: true }) }
+                  onRequestClose={ () => this.setState({ formPopoverWithAdditionalFooterContentOpen: false }) }
+                  additionalFooterContent={
+                    <TooltipTrigger
+                      placement="bottom"
+                      content="In this example, the additional footer content is a TooltipTrigger, but it could be any React node/component or even plain text.">
+                      <StatusIndicator>Tooltip</StatusIndicator>
+                    </TooltipTrigger>
+                  } />
               </td>
             </tr>
             <tr>

--- a/src/FormPopover.jsx
+++ b/src/FormPopover.jsx
@@ -37,6 +37,7 @@ class FormPopover extends React.Component {
               { submitComponent }
               { this.props.additionalControls }
               { cancelComponent }
+              { this._renderAdditionalFooterContent() }
               <ProcessingIndicator hidden={ !this.props.processing }/>
             </PopoverFooter>
           </Form>
@@ -58,6 +59,16 @@ class FormPopover extends React.Component {
     }
     this.props.onSubmit(event);
   }
+
+  _renderAdditionalFooterContent() {
+    if (this.props.additionalFooterContent) {
+      return (
+        <div className="rs-pull-right">
+          { this.props.additionalFooterContent }
+        </div>
+      );
+    }
+  }
 }
 
 FormPopover.propTypes = {
@@ -71,6 +82,7 @@ FormPopover.propTypes = {
   cancelButton: React.PropTypes.element.isRequired,
   submitButton: React.PropTypes.element.isRequired,
   additionalControls: React.PropTypes.node,
+  additionalFooterContent: React.PropTypes.node,
   // popover content
   children: React.PropTypes.node.isRequired,
   // popover
@@ -84,14 +96,14 @@ FormPopover.propTypes = {
 };
 
 FormPopover.defaultProps = {
+  additionalControls: [],
+  cancelButton: <Button canonStyle="link">Cancel</Button>,
   error: null,
   horizontal: true,
-  cancelButton: <Button canonStyle="link">Cancel</Button>,
-  submitButton: <Button canonStyle="primary">Submit</Button>,
-  additionalControls: [],
-  processing: false,
   isOpen: true,
-  placement: 'right'
+  placement: 'right',
+  processing: false,
+  submitButton: <Button canonStyle="primary">Submit</Button>
 };
 
 export default FormPopover;

--- a/test/FormPopoverSpec.jsx
+++ b/test/FormPopoverSpec.jsx
@@ -87,8 +87,8 @@ describe('FormPopover', () => {
   });
 
   describe('rendering', () => {
-    let additionalControls, anotherButton, cancel, errorIndicator, form, popover,
-      popoverBody, popoverFooter, popoverOverlay, processingIndicator, submit;
+    let additionalControls, additionalFooterContent, anotherButton, cancel, errorIndicator,
+      form, popover, popoverBody, popoverFooter, popoverOverlay, processingIndicator, submit;
 
     const shallowRenderPopover = (popoverProps) => {
       const renderer = TestUtils.createRenderer();
@@ -98,7 +98,14 @@ describe('FormPopover', () => {
       popoverOverlay = popover.props.children;
       form = popoverOverlay.props.children;
       [ popoverBody, popoverFooter ] = form.props.children;
-      [ errorIndicator, submit, additionalControls, cancel, processingIndicator ] = popoverFooter.props.children;
+      [
+        errorIndicator,
+        submit,
+        additionalControls,
+        cancel,
+        additionalFooterContent,
+        processingIndicator
+      ] = popoverFooter.props.children;
     };
 
     beforeEach(() => {
@@ -179,6 +186,28 @@ describe('FormPopover', () => {
 
     it('shows the cancel component', () => {
       expect(cancel.props.hidden).toBe(false);
+    });
+
+    describe('prop additionalFooterContent', () => {
+      const additionalContent = <div><span>content</span></div>;
+
+      beforeEach(() => {
+        shallowRenderPopover({ additionalFooterContent: additionalContent });
+      });
+
+      it('renders the content if prop is truthy', () => {
+        const actualContent = additionalFooterContent.props.children;
+        expect(actualContent).toBe(additionalContent);
+      });
+
+      it('does not render the wrapping element when prop is falsy', () => {
+        shallowRenderPopover();
+        expect(additionalFooterContent).toBe(undefined);
+      });
+
+      it('pulls the content to the right', () => {
+        expect(additionalFooterContent.props.className).toBe('rs-pull-right');
+      });
     });
 
     it('renders the ProcessingIndicator', () => {


### PR DESCRIPTION
This PR adds a new prop to the `FormPopover` component in order to allow developers to display additional right-aligned with the control buttons/links (e.g. submit and cancel).

#### Problem

I have a submittable popover component using the `FormPopover` component and I need to display a right-aligned tooltip on the footer. There is no appropriate way to use a `FormPopover` and display additional content after the control buttons. The only thing similar is the `additionalControls` prop, but it is rendered before the cancel component.

#### Updates based on suggestions

1. Renamed the new prop from `additionalInfo` to `additionalFooterContent`
2. Always right-align the extra content (see screenshots below). The implementation is straightforward: wrap the content in a `<div />` with class `rs-pull-right` (tests updated accordingly).
3. Improved demo

#### Tasks

- [x] Add support for new prop in `FormPopover`
- [x] Implement demo
- [x] Update changelog
- [x] Always right-align the additional content

---

### Screenshot: submittable popover displaying additional content as a `<TooltipTrigger />`

![image](https://cloud.githubusercontent.com/assets/46027/19349287/a1124466-9128-11e6-8c1a-3033aed754d1.png)

### Screenshot: The extra content plays nicely with the processing indicator on submittable popovers

![image](https://cloud.githubusercontent.com/assets/46027/19349336/e47a88b2-9128-11e6-82b0-b4411014178d.png)