### PR TITLE
chore(release): v 0.14.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Version 0.14.6
+1. Render passed in class names on the control group that is rendered by the FormField component.
+
 ### Version 0.14.5
 1. Render passed in dom attributes on rendered control group in FormField component.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "canon-react",
-  "version": "0.14.5",
+  "version": "0.14.6",
   "description": "Rackspace Canon components built with React",
   "repository": {
     "type": "git",


### PR DESCRIPTION
1. Render passed in class names on the control group that is rendered by the FormField component.